### PR TITLE
fix: 修复ManualShip页面的TypeScript编译错误

### DIFF
--- a/frontend/src/pages/manual-ship/ManualShip.tsx
+++ b/frontend/src/pages/manual-ship/ManualShip.tsx
@@ -27,7 +27,6 @@ export function ManualShip() {
   const [shipping, setShipping] = useState(false)
   const [customContent, setCustomContent] = useState('')
   const [showCustomModal, setShowCustomModal] = useState(false)
-  const [batchMode, setBatchMode] = useState<'auto' | 'custom' | null>(null)
 
   const loadPendingOrders = async () => {
     if (!_hasHydrated || !isAuthenticated || !token) return
@@ -50,10 +49,8 @@ export function ManualShip() {
   const loadAccounts = async () => {
     if (!_hasHydrated || !isAuthenticated || !token) return
     try {
-      const result = await getAccounts()
-      if (result.success) {
-        setAccounts(result.data || [])
-      }
+      const accounts = await getAccounts()
+      setAccounts(accounts || [])
     } catch {
       // 静默失败
     }
@@ -131,7 +128,6 @@ export function ManualShip() {
 
   const handleCustomShipSingle = (orderId: string) => {
     setSelectedOrders(new Set([orderId]))
-    setBatchMode('custom')
     setShowCustomModal(true)
   }
 
@@ -167,7 +163,6 @@ export function ManualShip() {
       addToast({ type: 'warning', message: '请先选择订单' })
       return
     }
-    setBatchMode('custom')
     setShowCustomModal(true)
   }
 


### PR DESCRIPTION
- 删除未使用的batchMode状态变量
- 修复getAccounts返回类型处理（返回Account[]而不是ApiResponse）
- 清理相关的setBatchMode调用

所有TypeScript错误已解决，可以正常编译