### PR TITLE
🐛 修复WebSocket消息处理和订单状态管理问题

### DIFF
--- a/XianyuAutoAsync.py
+++ b/XianyuAutoAsync.py
@@ -7558,12 +7558,17 @@ class XianyuLive:
                         except:
                             pass
 
-                        # 调用订单详情获取方法
-                        order_detail = await self.fetch_order_detail_info(order_id, temp_item_id, temp_user_id)
-                        if order_detail:
-                            logger.info(f'[{msg_time}] 【{self.cookie_id}】✅ 订单详情获取成功: {order_id}')
+                        # 检查是否已经在获取该订单详情
+                        order_detail_lock = self._order_detail_locks[order_id]
+                        if order_detail_lock.locked():
+                            logger.info(f'[{msg_time}] 【{self.cookie_id}】🔒 订单 {order_id} 详情正在被其他任务获取，跳过重复请求')
                         else:
-                            logger.warning(f'[{msg_time}] 【{self.cookie_id}】⚠️ 订单详情获取失败: {order_id}')
+                            # 调用订单详情获取方法
+                            order_detail = await self.fetch_order_detail_info(order_id, temp_item_id, temp_user_id)
+                            if order_detail:
+                                logger.info(f'[{msg_time}] 【{self.cookie_id}】✅ 订单详情获取成功: {order_id}')
+                            else:
+                                logger.warning(f'[{msg_time}] 【{self.cookie_id}】⚠️ 订单详情获取失败: {order_id}')
 
                     except Exception as detail_e:
                         logger.error(f'[{msg_time}] 【{self.cookie_id}】❌ 获取订单详情异常: {self._safe_str(detail_e)}')

--- a/utils/order_detail_fetcher.py
+++ b/utils/order_detail_fetcher.py
@@ -342,8 +342,17 @@ class OrderDetailFetcher:
                     logger.warning(f"等待页面加载状态失败: {e}")
                     # 继续执行，不中断流程
 
-                # 额外等待确保动态内容加载完成
-                await asyncio.sleep(3)
+                # 等待收货地址元素出现（最多等待10秒）
+                try:
+                    logger.info("等待收货地址元素加载...")
+                    await self.page.wait_for_selector('text=/收货地址/', timeout=10000)
+                    logger.info("收货地址元素已加载")
+                    # 收货地址加载后，再等待1秒确保完全渲染
+                    await asyncio.sleep(1)
+                except Exception as e:
+                    logger.warning(f"等待收货地址元素失败，使用默认等待时间: {e}")
+                    # 如果收货地址元素未出现，使用默认等待时间
+                    await asyncio.sleep(3)
 
                 # 获取并解析SKU信息
                 sku_info = await self._get_sku_content()


### PR DESCRIPTION
基于日志分析，修复了以下4个核心问题：

1. 收货人信息获取失败 - 增加动态等待时间
   - 问题：订单创建后立即获取详情，DOM未完全渲染
   - 修复：增加 wait_for_selector 等待收货地址元素加载（最多10秒）
   - 影响：减少浏览器重复启动，提高首次获取成功率

2. "你已发货"消息提取失败 - 支持tip类型消息
   - 问题：contentType=14 的tip消息不包含订单ID
   - 修复：从reminderUrl提取itemId和buyerId，通过数据库查询关联订单
   - 新增：db_manager.get_recent_order_by_item_and_buyer() 方法

3. 订单状态并发覆盖 - 添加乐观锁机制
   - 问题：并发更新基于相同旧状态，导致状态覆盖
   - 修复：添加version列，使用乐观锁防止并发冲突
   - 实现：expected_version参数，冲突时重试并检查最终状态

4. 并发浏览器启动 - 优化订单详情获取锁
   - 问题：两条相关消息几乎同时触发订单详情获取
   - 修复：调用前检查锁状态，跳过正在处理的订单
   - 影响：避免重复浏览器启动，节省资源

技术细节：
- 新增数据库迁移：orders表添加version列（默认值1）
- 乐观锁实现：UPDATE WHERE version = ? AND order_id = ?
- 锁状态检查：使用 asyncio.Lock.locked() 提前判断
- 兼容性：保留status和order_status双字段支持