### PR TITLE
feat: improve order sync and add automatic ratings

### DIFF
--- a/XianyuAutoAsync.py
+++ b/XianyuAutoAsync.py
@@ -6174,6 +6174,69 @@ class XianyuLive:
         )
         return response.get("body", {}) if isinstance(response, dict) else {}
 
+    async def get_im_head_info(self, cid, item_id, session_type=1):
+        """Return the trade header attached to an IM conversation.
+
+        Personal sellers cannot use the fish-shop/merchant sold-order API, but
+        the normal IM page still exposes the current trade through this PC API.
+        It is therefore the reliable discovery source for ordinary accounts.
+        """
+        if not cid or not item_id:
+            return {}
+        if not self.session:
+            await self.create_session()
+
+        payload = {
+            "itemId": int(item_id) if str(item_id).isdigit() else str(item_id),
+            "sessionId": int(cid) if str(cid).isdigit() else str(cid),
+            "sessionType": int(session_type or 1),
+        }
+        data_val = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+        timestamp = str(int(time.time() * 1000))
+        cookies = trans_cookies(self.cookies_str)
+        token_value = cookies.get("_m_h5_tk", "")
+        token = token_value.split("_", 1)[0] if token_value else ""
+        params = {
+            "jsv": "2.7.2",
+            "appKey": "34839810",
+            "t": timestamp,
+            "sign": generate_sign(timestamp, token, data_val),
+            "v": "1.0",
+            "type": "originaljson",
+            "accountSite": "xianyu",
+            "dataType": "json",
+            "timeout": "20000",
+            "api": "mtop.idle.trade.pc.message.headinfo",
+            "sessionOption": "AutoLoginOnly",
+            "spm_cnt": "a21ybx.im.0.0",
+            "valueType": "string",
+        }
+        headers = {
+            "accept": "application/json",
+            "content-type": "application/x-www-form-urlencoded",
+            "origin": "https://www.goofish.com",
+            "referer": "https://www.goofish.com/im",
+            "user-agent": DEFAULT_HEADERS.get("user-agent", "Mozilla/5.0"),
+            "cookie": self.cookies_str.replace("\n", "").replace("\r", ""),
+        }
+        async with self.session.post(
+            "https://h5api.m.goofish.com/h5/mtop.idle.trade.pc.message.headinfo/1.0/",
+            params=params,
+            data={"data": data_val},
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=20),
+        ) as response:
+            result = await response.json(content_type=None)
+            await self._merge_mtop_response_cookies(response, "IM订单头信息查询")
+
+        ret_list = result.get("ret", []) if isinstance(result, dict) else []
+        if any("SUCCESS" in str(value) for value in ret_list):
+            return result.get("data", {}) or {}
+        logger.warning(
+            f"【{self.cookie_id}】获取IM订单头信息失败: cid={cid}, item_id={item_id}, ret={ret_list}"
+        )
+        return {}
+
     async def send_im_text(self, cid, toid, text):
         text = str(text or "").strip()
         if not text:
@@ -8674,18 +8737,26 @@ class XianyuLive:
                     # 处理未加密的消息（如系统提示等）
                     msg_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
                     if isinstance(parsed_data, dict) and 'chatType' in parsed_data:
+                        # “chatType”不一定代表纯系统引导消息。付款/交易卡片也会
+                        # 带这个字段；旧代码在这里无条件 return，导致交易卡片从未
+                        # 进入 _extract_order_id，最新订单因此不会入库或触发自动发货。
+                        is_guidance_message = False
                         if 'operation' in parsed_data and 'content' in parsed_data['operation']:
                             content = parsed_data['operation']['content']
                             if 'sessionArouse' in content:
+                                is_guidance_message = True
                                 # 处理系统引导消息
                                 logger.info(f"[{msg_time}] 【{self.cookie_id}】【系统】小闲鱼智能提示:")
                                 if 'arouseChatScriptInfo' in content['sessionArouse']:
                                     for qa in content['sessionArouse']['arouseChatScriptInfo']:
                                         logger.info(f"  - {qa['chatScrip']}")
                             elif 'contentType' in content:
-                                # 其他类型的未加密消息
+                                # 交易卡片/其他未加密消息必须继续走订单解析链路。
                                 logger.warning(f"[{msg_time}] 【{self.cookie_id}】【系统】其他类型消息: {content}")
-                        return
+                        if is_guidance_message:
+                            return
+                        # 付款消息可能带 chatType，但不是引导消息；继续处理。
+                        message = parsed_data
                     else:
                         # 如果不是系统消息，将解析的数据作为message
                         message = parsed_data

--- a/XianyuAutoAsync.py
+++ b/XianyuAutoAsync.py
@@ -1391,10 +1391,17 @@ class XianyuLive:
 
         message_detail = message_1.get("10")
         event_text = message_detail.get("reminderContent", "") if isinstance(message_detail, dict) else ""
+        red_reminder = message_detail.get("redReminder", "") if isinstance(message_detail, dict) else ""
         if not event_text:
             content = message_1.get("6")
             content_detail = content.get("3") if isinstance(content, dict) else None
             event_text = content_detail.get("2", "") if isinstance(content_detail, dict) else ""
+
+        # 新版确认收货卡片不再发送旧的“[买家确认收货，交易成功]”文案，
+        # 而是发送“快给ta一个评价吧～”；评价通知卡片则显示“[我完成了评价]”。
+        # 两类卡片都携带明确的交易成功语义，可以安全地将订单推进到 completed。
+        if str(red_reminder).strip() == "交易成功":
+            return "completed"
 
         return {
             "[我已拍下，待付款]": "processing",
@@ -1406,9 +1413,43 @@ class XianyuLive:
             "[你已发货，请等待买家确认收货]": "shipped",
             "[买家确认收货，交易成功]": "completed",
             "[你已确认收货，交易成功]": "completed",
+            "快给ta一个评价吧~": "completed",
+            "快给ta一个评价吧～": "completed",
+            "[我完成了评价]": "completed",
             "[退款成功，钱款已原路退返]": "cancelled",
             "[你关闭了订单，钱款已原路退返]": "cancelled",
         }.get(str(event_text).strip())
+
+    @staticmethod
+    def _is_rate_completion_event(message: dict) -> bool:
+        """判断是否为卖家已经完成评价的系统回执。"""
+        if not isinstance(message, dict):
+            return False
+        message_1 = message.get("1")
+        message_detail = message_1.get("10") if isinstance(message_1, dict) else None
+        if not isinstance(message_detail, dict):
+            return False
+        return str(message_detail.get("reminderContent") or "").strip() == "[我完成了评价]"
+
+    async def _auto_rate_completed_order(self, order_id: str) -> None:
+        """订单事件确认交易完成后，立即尝试自动评价。"""
+        try:
+            from app.auto_rate_task import rate_completed_order_if_enabled
+
+            result = await rate_completed_order_if_enabled(
+                self.cookie_id,
+                order_id,
+                source="order_event",
+            )
+            if result.get("success"):
+                logger.info(f"【{self.cookie_id}】订单完成后自动评价成功: {order_id}")
+            elif not result.get("skipped"):
+                logger.warning(
+                    f"【{self.cookie_id}】订单完成后自动评价失败: {order_id}, "
+                    f"原因: {result.get('message', '未知')}"
+                )
+        except Exception as exc:
+            logger.error(f"【{self.cookie_id}】订单完成后触发自动评价异常: {order_id}, {self._safe_str(exc)}")
 
     def _save_order_event_snapshot(
         self,
@@ -5220,10 +5261,10 @@ class XianyuLive:
                     amount = result.get('amount', '')
 
                     # 获取订单时间和收货人信息
-                    order_time = result.get('order_time', None)
-                    receiver_name = result.get('receiver_name', None)
-                    receiver_phone = result.get('receiver_phone', None)
-                    receiver_address = result.get('receiver_address', None)
+                    order_time = result.get('order_time') or None
+                    receiver_name = result.get('receiver_name') or None
+                    receiver_phone = result.get('receiver_phone') or None
+                    receiver_address = result.get('receiver_address') or None
 
                     if spec_name and spec_value:
                         logger.info(f"【{self.cookie_id}】📋 规格名称: {spec_name}")
@@ -5250,7 +5291,18 @@ class XianyuLive:
                         if not cookie_info:
                             logger.warning(f"Cookie ID {self.cookie_id} 不存在于cookies表中，丢弃订单 {order_id}")
                         else:
-                            # 先保存订单基本信息（包含时间和收货人信息）
+                            detail_status = result.get('order_status')
+                            existing_order = db_manager.get_order_by_id(order_id)
+                            existing_status = (existing_order or {}).get('order_status')
+                            if detail_status in (None, '', 'unknown') and existing_status not in (None, '', 'unknown'):
+                                logger.info(
+                                    f"【{self.cookie_id}】订单详情未识别出状态，保留事件状态: "
+                                    f"{order_id} -> {existing_status}"
+                                )
+                                detail_status = None
+
+                            # 先保存订单基本信息（包含时间和收货人信息）。空字符串和 unknown
+                            # 不覆盖交易卡片已经识别出的有效时间与状态。
                             success = db_manager.insert_or_update_order(
                                 order_id=order_id,
                                 item_id=item_id,
@@ -5259,7 +5311,7 @@ class XianyuLive:
                                 spec_value=spec_value,
                                 quantity=quantity,
                                 amount=amount,
-                                order_status=result.get('order_status'),  # 添加订单状态
+                                order_status=detail_status,
                                 cookie_id=self.cookie_id,
                                 created_at=order_time,
                                 receiver_name=receiver_name,
@@ -8846,6 +8898,12 @@ class XianyuLive:
                             item_id=temp_item_id,
                             buyer_id=temp_user_id,
                         )
+                        order_event_status = self._extract_order_event_status(message)
+                        rate_completion_event = self._is_rate_completion_event(message)
+                        if rate_completion_event:
+                            from app.db_manager import db_manager
+                            db_manager.mark_order_rated(order_id, True)
+                            logger.info(f"【{self.cookie_id}】收到评价完成回执，订单已标记为已评价: {order_id}")
 
                         # 检查是否已经在获取该订单详情
                         order_detail_lock = self._order_detail_locks[order_id]
@@ -8858,6 +8916,11 @@ class XianyuLive:
                                 logger.info(f'[{msg_time}] 【{self.cookie_id}】✅ 订单详情获取成功: {order_id}')
                             else:
                                 logger.warning(f'[{msg_time}] 【{self.cookie_id}】⚠️ 订单详情获取失败: {order_id}')
+
+                        # “确认收货/去评价”事件本身已经能确认交易完成，无需等待5分钟轮询。
+                        # 使用追踪任务执行，避免评价接口阻塞后续消息接收。
+                        if order_event_status == "completed" and not rate_completion_event:
+                            self._create_tracked_task(self._auto_rate_completed_order(order_id))
 
                     except Exception as detail_e:
                         logger.error(f'[{msg_time}] 【{self.cookie_id}】❌ 获取订单详情异常: {self._safe_str(detail_e)}')

--- a/app/auto_rate_task.py
+++ b/app/auto_rate_task.py
@@ -23,6 +23,18 @@ DEFAULT_LOOKBACK_DAYS = int(os.getenv("AUTO_RATE_TASK_LOOKBACK_DAYS", "10") or 1
 DEFAULT_COOLDOWN_MINUTES = int(os.getenv("AUTO_RATE_TASK_COOLDOWN_MINUTES", "30") or 30)
 
 
+_order_rate_locks: dict[str, asyncio.Lock] = {}
+
+
+def _get_order_rate_lock(cookie_id: str, order_id: str) -> asyncio.Lock:
+    key = f"{cookie_id}:{order_id}"
+    lock = _order_rate_locks.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _order_rate_locks[key] = lock
+    return lock
+
+
 def _status_from_result(result: Dict[str, Any]) -> str:
     if result.get("success"):
         return "success"
@@ -123,6 +135,46 @@ async def rate_order_once(
     }
 
 
+async def rate_completed_order_if_enabled(
+    cookie_id: str,
+    order_id: str,
+    *,
+    source: str = "order_event",
+) -> Dict[str, Any]:
+    """仅在账号开启自动评价且订单确已完成时执行一次评价。
+
+    订单事件和5分钟补偿任务可能同时命中同一订单，因此这里按账号和订单加锁，
+    并在锁内重新检查 is_rated，避免重复调用闲鱼评价接口。
+    """
+    cookie_id = str(cookie_id or "").strip()
+    order_id = str(order_id or "").strip()
+    if not cookie_id or not order_id:
+        return {"success": False, "skipped": True, "status": "skipped", "message": "账号或订单号为空"}
+    if not db_manager.get_auto_comment(cookie_id):
+        return {"success": False, "skipped": True, "status": "disabled", "message": "自动评价未开启"}
+
+    lock = _get_order_rate_lock(cookie_id, order_id)
+    async with lock:
+        order = db_manager.get_order_by_id(order_id)
+        if not order:
+            return {"success": False, "skipped": True, "status": "skipped", "message": "订单不存在"}
+        if str(order.get("order_status") or "") != "completed":
+            return {"success": False, "skipped": True, "status": "not_completed", "message": "订单尚未完成"}
+        if order.get("is_rated"):
+            return {"success": True, "skipped": True, "status": "already_rated", "message": "订单已评价"}
+
+        template = db_manager.get_active_comment_template(cookie_id)
+        if not template or not str(template.get("content") or "").strip():
+            return {"success": False, "skipped": True, "status": "missing_template", "message": "未设置激活的好评模板"}
+
+        return await rate_order_once(
+            cookie_id,
+            order_id,
+            str(template.get("content") or "").strip(),
+            source=source,
+        )
+
+
 async def run_auto_rate_batch(
     *,
     batch_limit: int = DEFAULT_BATCH_LIMIT,
@@ -167,11 +219,9 @@ async def run_auto_rate_batch(
             logger.info(f"【{cookie_id}】自动补评价找到 {len(orders)} 个待处理订单")
             for order in orders:
                 stats["orders"] += 1
-                result = await rate_order_once(
+                result = await rate_completed_order_if_enabled(
                     cookie_id,
                     order.get("order_id"),
-                    str(template.get("content") or "").strip(),
-                    batch_id=batch_id,
                     source="scheduled_rate",
                 )
                 if result.get("success"):

--- a/app/auto_rate_task.py
+++ b/app/auto_rate_task.py
@@ -1,0 +1,206 @@
+"""自动补评价任务。
+
+轻量本地调度版本：不引入上游独立 scheduler 服务，直接复用当前 SQLite、Cookie 和好评模板。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+from loguru import logger
+
+from app.db_manager import db_manager
+from app.services.rate_service import RateService
+
+
+DEFAULT_INTERVAL_SECONDS = int(os.getenv("AUTO_RATE_TASK_INTERVAL_SECONDS", "300") or 300)
+DEFAULT_BATCH_LIMIT = int(os.getenv("AUTO_RATE_TASK_BATCH_LIMIT", "5") or 5)
+DEFAULT_LOOKBACK_DAYS = int(os.getenv("AUTO_RATE_TASK_LOOKBACK_DAYS", "10") or 10)
+DEFAULT_COOLDOWN_MINUTES = int(os.getenv("AUTO_RATE_TASK_COOLDOWN_MINUTES", "30") or 30)
+
+
+def _status_from_result(result: Dict[str, Any]) -> str:
+    if result.get("success"):
+        return "success"
+    if result.get("session_expired"):
+        return "cookie_expired"
+    return "failed"
+
+
+async def rate_order_once(
+    cookie_id: str,
+    order_id: str,
+    comment: Optional[str] = None,
+    *,
+    batch_id: Optional[str] = None,
+    source: str = "manual",
+) -> Dict[str, Any]:
+    """对单个订单执行一次评价，并写入日志。"""
+    cookie_id = str(cookie_id or "").strip()
+    order_id = str(order_id or "").strip()
+    batch_id = batch_id or f"{source}_{uuid.uuid4()}"
+
+    order_info = db_manager.get_order_by_id(order_id)
+    if not order_info:
+        message = "订单不存在"
+        db_manager.add_scheduled_rate_log(batch_id, cookie_id, order_id=order_id, status="skipped", message=message)
+        return {"success": False, "message": message, "status": "skipped"}
+
+    order_cookie_id = str(order_info.get("cookie_id") or "").strip()
+    if order_cookie_id and order_cookie_id != cookie_id:
+        message = "订单不属于当前账号"
+        db_manager.add_scheduled_rate_log(
+            batch_id, cookie_id, order_id=order_id, item_id=order_info.get("item_id"),
+            buyer_id=order_info.get("buyer_id"),
+            status="skipped", message=message,
+        )
+        return {"success": False, "message": message, "status": "skipped"}
+
+    if order_info.get("is_rated"):
+        message = "订单已标记为已评价"
+        db_manager.add_scheduled_rate_log(
+            batch_id, cookie_id, order_id=order_id, item_id=order_info.get("item_id"),
+            buyer_id=order_info.get("buyer_id"),
+            status="already_rated", message=message,
+        )
+        return {"success": True, "message": message, "status": "already_rated", "already_rated": True}
+
+    if not comment:
+        template = db_manager.get_active_comment_template(cookie_id)
+        if not template or not str(template.get("content") or "").strip():
+            message = "未设置激活的好评模板"
+            db_manager.add_scheduled_rate_log(
+                batch_id, cookie_id, order_id=order_id, item_id=order_info.get("item_id"),
+                buyer_id=order_info.get("buyer_id"),
+                status="missing_template", message=message,
+            )
+            return {"success": False, "message": message, "status": "missing_template"}
+        comment = str(template.get("content") or "").strip()
+
+    cookie_string = db_manager.get_cookie(cookie_id)
+    if not cookie_string:
+        message = "账号 Cookie 为空或不存在"
+        db_manager.add_scheduled_rate_log(
+            batch_id, cookie_id, order_id=order_id, item_id=order_info.get("item_id"),
+            buyer_id=order_info.get("buyer_id"),
+            comment=comment, status="cookie_expired", message=message,
+        )
+        return {"success": False, "message": message, "status": "cookie_expired"}
+
+    rate_service = RateService(cookie_string, account_id=cookie_id)
+    result = await rate_service.rate_buyer(order_id, comment)
+    status = _status_from_result(result)
+    message = str(result.get("message") or "")
+
+    db_manager.add_scheduled_rate_log(
+        batch_id=batch_id,
+        cookie_id=cookie_id,
+        order_id=order_id,
+        item_id=order_info.get("item_id"),
+        buyer_id=order_info.get("buyer_id"),
+        comment=comment,
+        status=status,
+        message=message,
+        raw_response=result.get("raw") or result,
+    )
+
+    if result.get("success"):
+        db_manager.mark_order_rated(order_id, True)
+    else:
+        db_manager.mark_order_rated(order_id, False, message)
+
+    return {
+        "success": bool(result.get("success")),
+        "message": message,
+        "status": status,
+        "order_id": order_id,
+        "cookie_id": cookie_id,
+        "already_rated": bool(result.get("already_rated")),
+    }
+
+
+async def run_auto_rate_batch(
+    *,
+    batch_limit: int = DEFAULT_BATCH_LIMIT,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    cooldown_minutes: int = DEFAULT_COOLDOWN_MINUTES,
+    allowed_cookie_ids: Optional[set[str]] = None,
+) -> Dict[str, Any]:
+    """执行一轮自动补评价。"""
+    batch_id = str(uuid.uuid4())
+    started_at = time.time()
+    stats = {
+        "batch_id": batch_id,
+        "accounts": 0,
+        "orders": 0,
+        "success": 0,
+        "failed": 0,
+        "skipped": 0,
+    }
+
+    all_cookies = db_manager.get_all_cookies()
+    for cookie_id in list(all_cookies.keys()):
+        try:
+            if allowed_cookie_ids is not None and cookie_id not in allowed_cookie_ids:
+                continue
+            if not db_manager.get_auto_comment(cookie_id):
+                continue
+            stats["accounts"] += 1
+            template = db_manager.get_active_comment_template(cookie_id)
+            if not template or not str(template.get("content") or "").strip():
+                logger.info(f"【{cookie_id}】未设置激活好评模板，跳过自动补评价")
+                continue
+
+            orders = db_manager.get_pending_auto_comment_orders(
+                cookie_id,
+                limit=batch_limit,
+                days=lookback_days,
+                cooldown_minutes=cooldown_minutes,
+            )
+            if not orders:
+                continue
+
+            logger.info(f"【{cookie_id}】自动补评价找到 {len(orders)} 个待处理订单")
+            for order in orders:
+                stats["orders"] += 1
+                result = await rate_order_once(
+                    cookie_id,
+                    order.get("order_id"),
+                    str(template.get("content") or "").strip(),
+                    batch_id=batch_id,
+                    source="scheduled_rate",
+                )
+                if result.get("success"):
+                    stats["success"] += 1
+                elif result.get("status") in {"skipped", "missing_template", "already_rated"}:
+                    stats["skipped"] += 1
+                else:
+                    stats["failed"] += 1
+                await asyncio.sleep(1)
+        except Exception as exc:
+            stats["failed"] += 1
+            logger.error(f"【{cookie_id}】自动补评价账号处理异常: {exc}")
+
+    stats["duration_seconds"] = round(time.time() - started_at, 2)
+    if stats["orders"]:
+        logger.info(f"自动补评价批次完成: {stats}")
+    return stats
+
+
+async def auto_rate_task_loop(interval_seconds: int = DEFAULT_INTERVAL_SECONDS):
+    """后台自动补评价循环。"""
+    interval_seconds = max(60, int(interval_seconds or DEFAULT_INTERVAL_SECONDS))
+    logger.info(f"自动补评价任务已启动，检查间隔 {interval_seconds} 秒")
+    while True:
+        try:
+            await run_auto_rate_batch()
+        except asyncio.CancelledError:
+            logger.info("自动补评价任务已取消")
+            raise
+        except Exception as exc:
+            logger.error(f"自动补评价任务异常: {exc}")
+        await asyncio.sleep(interval_seconds)

--- a/app/db_manager.py
+++ b/app/db_manager.py
@@ -257,6 +257,37 @@ class DBManager:
             )
             ''')
 
+            # 自动评价模板与执行日志。默认关闭，只有账号明确开启后才会运行。
+            cursor.execute('''
+            CREATE TABLE IF NOT EXISTS comment_templates (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                cookie_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                content TEXT NOT NULL,
+                is_active INTEGER DEFAULT 0,
+                sort_order INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (cookie_id) REFERENCES cookies(id) ON DELETE CASCADE
+            )
+            ''')
+            cursor.execute('''
+            CREATE TABLE IF NOT EXISTS scheduled_rate_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                batch_id TEXT NOT NULL,
+                cookie_id TEXT NOT NULL,
+                order_id TEXT,
+                item_id TEXT,
+                buyer_id TEXT,
+                comment TEXT,
+                status TEXT NOT NULL,
+                message TEXT,
+                raw_response TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (cookie_id) REFERENCES cookies(id) ON DELETE CASCADE
+            )
+            ''')
+
             cursor.execute('''
             CREATE TABLE IF NOT EXISTS delivery_block_rules (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -735,6 +766,23 @@ class DBManager:
                 logger.info("添加cookies表的pause_duration列...")
                 cursor.execute("ALTER TABLE cookies ADD COLUMN pause_duration INTEGER DEFAULT 10")
                 logger.info("数据库迁移完成：添加pause_duration列")
+
+            if 'auto_comment' not in cookie_columns:
+                cursor.execute("ALTER TABLE cookies ADD COLUMN auto_comment INTEGER DEFAULT 0")
+                logger.info("数据库迁移完成：添加cookies.auto_comment列")
+
+            cursor.execute("PRAGMA table_info(orders)")
+            order_columns = {column[1] for column in cursor.fetchall()}
+            for column_name, column_type in {
+                'is_rated': 'INTEGER DEFAULT 0',
+                'rated_at': 'TIMESTAMP',
+                'rate_error': 'TEXT',
+            }.items():
+                if column_name not in order_columns:
+                    cursor.execute(f"ALTER TABLE orders ADD COLUMN {column_name} {column_type}")
+                    logger.info(f"数据库迁移完成：添加orders.{column_name}列")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_orders_auto_comment ON orders(cookie_id, order_status, is_rated, updated_at)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_scheduled_rate_logs_cookie_time ON scheduled_rate_logs(cookie_id, created_at DESC)")
 
             profile_columns = {
                 'nickname': "TEXT DEFAULT ''",
@@ -6094,7 +6142,8 @@ class DBManager:
                 # 先尝试查询包含version的订单
                 cursor.execute('''
                 SELECT order_id, item_id, buyer_id, spec_name, spec_value,
-                       quantity, amount, order_status, cookie_id, is_bargain, created_at, updated_at, version, chat_id
+                       quantity, amount, order_status, cookie_id, is_bargain, created_at, updated_at, version, chat_id,
+                       is_rated, rated_at, rate_error
                 FROM orders WHERE order_id = ?
                 ''', (order_id,))
 
@@ -6116,7 +6165,10 @@ class DBManager:
                         'created_at': row[10],
                         'updated_at': row[11],
                         'version': row[12] if len(row) > 12 else 1,  # 默认版本为1
-                        'chat_id': row[13] if len(row) > 13 else ''
+                        'chat_id': row[13] if len(row) > 13 else '',
+                        'is_rated': bool(row[14]) if len(row) > 14 else False,
+                        'rated_at': row[15] if len(row) > 15 else None,
+                        'rate_error': row[16] if len(row) > 16 else None,
                     }
                 return None
 
@@ -7152,6 +7204,123 @@ class DBManager:
             except Exception as e:
                 logger.error(f"获取订单列表失败: {e}")
                 return []
+
+
+    # -------------------- 自动评价 --------------------
+    def get_auto_comment(self, cookie_id: str) -> bool:
+        with self.lock:
+            cursor = self.conn.cursor()
+            cursor.execute("SELECT auto_comment FROM cookies WHERE id = ?", (cookie_id,))
+            row = cursor.fetchone()
+            return bool(row and row[0])
+
+    def update_auto_comment(self, cookie_id: str, enabled: bool) -> bool:
+        with self.lock:
+            cursor = self.conn.cursor()
+            cursor.execute("UPDATE cookies SET auto_comment = ? WHERE id = ?", (int(enabled), cookie_id))
+            self.conn.commit()
+            return cursor.rowcount > 0
+
+    def get_comment_templates(self, cookie_id: str) -> List[Dict]:
+        with self.lock:
+            cursor = self.conn.cursor()
+            cursor.execute('''
+                SELECT id, name, content, is_active, sort_order, created_at, updated_at
+                FROM comment_templates WHERE cookie_id = ? ORDER BY sort_order, id
+            ''', (cookie_id,))
+            return [dict(zip(
+                ('id', 'name', 'content', 'is_active', 'sort_order', 'created_at', 'updated_at'),
+                (r[0], r[1], r[2], bool(r[3]), r[4], r[5], r[6])
+            )) for r in cursor.fetchall()]
+
+    def get_active_comment_template(self, cookie_id: str) -> Optional[Dict]:
+        templates = self.get_comment_templates(cookie_id)
+        return next((item for item in templates if item['is_active']), None)
+
+    def save_active_comment_template(self, cookie_id: str, name: str, content: str) -> Optional[int]:
+        """保存一个账号的当前模板；已有激活模板时直接更新。"""
+        with self.lock:
+            cursor = self.conn.cursor()
+            cursor.execute("SELECT id FROM comment_templates WHERE cookie_id = ? AND is_active = 1 LIMIT 1", (cookie_id,))
+            row = cursor.fetchone()
+            if row:
+                cursor.execute('''UPDATE comment_templates SET name = ?, content = ?, updated_at = CURRENT_TIMESTAMP
+                                  WHERE id = ?''', (name, content, row[0]))
+                template_id = row[0]
+            else:
+                cursor.execute("UPDATE comment_templates SET is_active = 0 WHERE cookie_id = ?", (cookie_id,))
+                cursor.execute('''INSERT INTO comment_templates(cookie_id, name, content, is_active, sort_order)
+                                  VALUES (?, ?, ?, 1, 1)''', (cookie_id, name, content))
+                template_id = cursor.lastrowid
+            self.conn.commit()
+            return int(template_id)
+
+    def mark_order_rated(self, order_id: str, is_rated: bool = True, error_message: str = None) -> bool:
+        with self.lock:
+            cursor = self.conn.cursor()
+            if is_rated:
+                cursor.execute('''UPDATE orders SET is_rated = 1, rated_at = CURRENT_TIMESTAMP,
+                                  rate_error = NULL, updated_at = CURRENT_TIMESTAMP WHERE order_id = ?''', (order_id,))
+            else:
+                cursor.execute('''UPDATE orders SET rate_error = ?, updated_at = CURRENT_TIMESTAMP
+                                  WHERE order_id = ?''', (str(error_message or '')[:1000], order_id))
+            self.conn.commit()
+            return cursor.rowcount > 0
+
+    def add_scheduled_rate_log(self, batch_id: str, cookie_id: str, order_id: str = None,
+                               item_id: str = None, buyer_id: str = None, comment: str = None,
+                               status: str = 'failed', message: str = None, raw_response: Any = None) -> Optional[int]:
+        with self.lock:
+            cursor = self.conn.cursor()
+            raw_text = raw_response if isinstance(raw_response, str) else (
+                json.dumps(raw_response, ensure_ascii=False, default=str) if raw_response is not None else None
+            )
+            cursor.execute('''INSERT INTO scheduled_rate_logs
+                (batch_id, cookie_id, order_id, item_id, buyer_id, comment, status, message, raw_response)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                (batch_id, cookie_id, order_id, item_id, buyer_id, comment, status, message, raw_text))
+            self.conn.commit()
+            return int(cursor.lastrowid)
+
+    def get_scheduled_rate_logs(self, user_id: int = None, cookie_id: str = None,
+                                limit: int = 100, offset: int = 0) -> List[Dict]:
+        with self.lock:
+            conditions, params = [], []
+            if user_id is not None:
+                conditions.append("c.user_id = ?")
+                params.append(user_id)
+            if cookie_id:
+                conditions.append("l.cookie_id = ?")
+                params.append(cookie_id)
+            where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+            params.extend((max(1, min(int(limit), 500)), max(0, int(offset))))
+            cursor = self.conn.cursor()
+            cursor.execute(f'''SELECT l.id, l.batch_id, l.cookie_id, l.order_id, l.item_id, l.buyer_id,
+                               l.comment, l.status, l.message, l.raw_response, l.created_at
+                               FROM scheduled_rate_logs l LEFT JOIN cookies c ON c.id = l.cookie_id
+                               {where} ORDER BY l.created_at DESC, l.id DESC LIMIT ? OFFSET ?''', params)
+            keys = ('id', 'batch_id', 'cookie_id', 'order_id', 'item_id', 'buyer_id',
+                    'comment', 'status', 'message', 'raw_response', 'created_at')
+            return [dict(zip(keys, row)) for row in cursor.fetchall()]
+
+    def get_pending_auto_comment_orders(self, cookie_id: str, limit: int = 5,
+                                        days: int = 10, cooldown_minutes: int = 30) -> List[Dict]:
+        with self.lock:
+            cursor = self.conn.cursor()
+            cursor.execute('''SELECT o.order_id, o.item_id, o.buyer_id, o.order_status, o.cookie_id,
+                              o.created_at, o.updated_at, o.is_rated, o.rated_at, o.rate_error
+                              FROM orders o WHERE o.cookie_id = ? AND o.order_status = 'completed'
+                              AND COALESCE(o.is_rated, 0) = 0
+                              AND datetime(o.created_at) >= datetime('now', ?)
+                              AND NOT EXISTS (SELECT 1 FROM scheduled_rate_logs l WHERE l.order_id = o.order_id
+                                  AND l.status IN ('failed', 'cookie_expired')
+                                  AND datetime(l.created_at) >= datetime('now', ?))
+                              ORDER BY datetime(o.created_at) DESC LIMIT ?''',
+                           (cookie_id, f'-{max(1, int(days))} days',
+                            f'-{max(1, int(cooldown_minutes))} minutes', max(1, min(int(limit), 50))))
+            keys = ('order_id', 'item_id', 'buyer_id', 'order_status', 'cookie_id',
+                    'created_at', 'updated_at', 'is_rated', 'rated_at', 'rate_error')
+            return [dict(zip(keys, row)) for row in cursor.fetchall()]
 
 
 # 全局单例

--- a/app/reply_server.py
+++ b/app/reply_server.py
@@ -16,7 +16,9 @@ import uvicorn
 import pandas as pd
 import io
 import asyncio
+import base64
 import sqlite3
+from datetime import datetime
 from collections import defaultdict
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -27,8 +29,14 @@ from app.product_automation import ProductAutomationService
 from app.file_log_collector import setup_file_logging, get_file_log_collector
 from app.ai_reply_engine import ai_reply_engine
 from app.routers.delivery_block import create_delivery_block_router
+from app.routers.auto_rating import create_auto_rating_router
 from utils.qr_login import qr_login_manager
 from utils.xianyu_utils import trans_cookies
+from utils.time_utils import (
+    get_local_now,
+    local_date_to_utc_end_exclusive,
+    local_date_to_utc_start,
+)
 from utils.image_utils import image_manager
 from utils.order_status_rules import (
     get_order_status,
@@ -68,6 +76,11 @@ qr_check_tasks = {}  # 保持后台任务引用，避免扫码后的Cookie准备
 # 账号密码登录会话管理
 password_login_sessions = {}  # {session_id: {'account_id': str, 'account': str, 'password': str, 'show_browser': bool, 'status': str, 'verification_url': str, 'qr_code_url': str, 'slider_instance': object, 'task': asyncio.Task, 'timestamp': float}}
 password_login_locks = defaultdict(lambda: asyncio.Lock())
+
+# 历史订单同步任务（从 fix 项目迁移）。任务状态保存在内存，订单结果写入本地 SQLite。
+ORDER_HISTORY_SYNC_JOB_RETENTION_SECONDS = 3600
+order_history_sync_jobs: Dict[str, Dict[str, Any]] = {}
+order_history_sync_tasks: Dict[str, asyncio.Task] = {}
 
 # 不再需要单独的密码初始化，由数据库初始化时处理
 
@@ -338,6 +351,30 @@ else:
 
 app.include_router(create_delivery_block_router(get_current_user, db_manager))
 logger.info("已注册发货拦截规则路由")
+app.include_router(create_auto_rating_router(get_current_user, db_manager))
+logger.info("已注册自动评价路由")
+
+_auto_rating_task: Optional[asyncio.Task] = None
+
+
+@app.on_event("startup")
+async def start_auto_rating_task():
+    global _auto_rating_task
+    from app.auto_rate_task import auto_rate_task_loop
+    if _auto_rating_task is None or _auto_rating_task.done():
+        _auto_rating_task = asyncio.create_task(auto_rate_task_loop())
+
+
+@app.on_event("shutdown")
+async def stop_auto_rating_task():
+    global _auto_rating_task
+    if _auto_rating_task and not _auto_rating_task.done():
+        _auto_rating_task.cancel()
+        try:
+            await _auto_rating_task
+        except asyncio.CancelledError:
+            pass
+    _auto_rating_task = None
 
 # 初始化文件日志收集器
 setup_file_logging()
@@ -7263,6 +7300,273 @@ def update_item_multi_quantity_delivery(cookie_id: str, item_id: str, delivery_d
 
 # ==================== 订单管理接口 ====================
 
+
+class OrderHistorySyncRequest(BaseModel):
+    """按本地日期范围抓取卖家中心历史订单。"""
+    cookie_id: Optional[str] = None
+    start_date: str
+    end_date: str
+    max_orders: int = 120
+    fetch_details: bool = True
+
+
+def _history_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _history_amount(value: Any) -> Optional[str]:
+    text = _history_text(value)
+    if not text:
+        return None
+    cleaned = text.replace('¥', '').replace('￥', '').replace(',', '').strip()
+    try:
+        return f'{float(cleaned):.2f}'
+    except (TypeError, ValueError):
+        return text
+
+
+def _history_job_snapshot(job: Dict[str, Any]) -> Dict[str, Any]:
+    result = {key: job.get(key) for key in (
+        'job_id', 'status', 'message', 'error', 'created_at', 'started_at', 'finished_at',
+        'request', 'current_account', 'current_order_id', 'accounts_total', 'accounts_completed',
+        'orders_discovered', 'orders_processed', 'orders_saved', 'orders_skipped',
+        'orders_failed', 'matched_orders',
+    )}
+    result['warnings'] = list(job.get('warnings') or [])
+    return result
+
+
+def _history_warning(job: Dict[str, Any], message: str) -> None:
+    warnings = job.setdefault('warnings', [])
+    if len(warnings) < 20:
+        warnings.append(str(message))
+
+
+def _cleanup_order_history_sync_jobs() -> None:
+    now = time.time()
+    expired = [job_id for job_id, job in order_history_sync_jobs.items()
+               if job.get('status') in {'completed', 'failed', 'cancelled'}
+               and job.get('finished_ts')
+               and now - job['finished_ts'] > ORDER_HISTORY_SYNC_JOB_RETENTION_SECONDS]
+    for job_id in expired:
+        order_history_sync_jobs.pop(job_id, None)
+        order_history_sync_tasks.pop(job_id, None)
+
+
+def _save_history_order_candidate(cookie_id: str, candidate: Dict[str, Any]) -> bool:
+    from utils.order_history_sync import normalize_order_history_status
+
+    order_id = _history_text(candidate.get('order_id'))
+    if not order_id:
+        return False
+    status = normalize_order_history_status(candidate.get('order_status')) or _history_text(candidate.get('order_status'))
+    return bool(db_manager.insert_or_update_order(
+        order_id=order_id,
+        item_id=_history_text(candidate.get('item_id')),
+        buyer_id=_history_text(candidate.get('buyer_id')),
+        amount=_history_amount(candidate.get('amount')),
+        order_status=status,
+        cookie_id=cookie_id,
+        created_at=_history_text(candidate.get('platform_created_at')),
+    ))
+
+
+def _save_history_order_detail(cookie_id: str, candidate: Dict[str, Any], detail: Dict[str, Any]) -> bool:
+    from utils.order_history_sync import normalize_order_history_status
+
+    order_id = _history_text(detail.get('order_id')) or _history_text(candidate.get('order_id'))
+    if not order_id:
+        return False
+    status = normalize_order_history_status(detail.get('order_status')) or _history_text(detail.get('order_status'))
+    sku = detail.get('sku_info') if isinstance(detail.get('sku_info'), dict) else {}
+    return bool(db_manager.insert_or_update_order(
+        order_id=order_id,
+        item_id=_history_text(detail.get('item_id')) or _history_text(candidate.get('item_id')),
+        buyer_id=_history_text(candidate.get('buyer_id')),
+        spec_name=_history_text(detail.get('spec_name') or sku.get('spec_name')),
+        spec_value=_history_text(detail.get('spec_value') or sku.get('spec_value')),
+        quantity=_history_text(detail.get('quantity') or sku.get('quantity')),
+        amount=_history_amount(detail.get('amount') or sku.get('amount') or candidate.get('amount')),
+        order_status=status,
+        cookie_id=cookie_id,
+        created_at=_history_text(detail.get('order_time') or sku.get('order_time') or candidate.get('platform_created_at')),
+        receiver_name=_history_text(detail.get('receiver_name') or sku.get('receiver_name')),
+        receiver_phone=_history_text(detail.get('receiver_phone') or sku.get('receiver_phone')),
+        receiver_address=_history_text(detail.get('receiver_address') or sku.get('receiver_address')),
+    ))
+
+
+async def _run_order_history_sync_job(job_id: str) -> None:
+    job = order_history_sync_jobs.get(job_id)
+    if not job:
+        return
+    from utils.order_history_sync import OrderHistoryPageFetcher, OrderHistorySyncError
+
+    try:
+        request_data = dict(job.get('request') or {})
+        utc_start = local_date_to_utc_start(request_data.get('start_date'))
+        utc_end = local_date_to_utc_end_exclusive(request_data.get('end_date'))
+        if not utc_start or not utc_end or utc_start >= utc_end:
+            raise ValueError('日期格式错误或开始日期不早于结束日期，应为 YYYY-MM-DD')
+        max_orders = min(max(int(request_data.get('max_orders') or 120), 1), 500)
+        fetch_details = bool(request_data.get('fetch_details', True))
+        cookies = db_manager.get_all_cookies(job.get('user_id'))
+        selected = _history_text(request_data.get('cookie_id'))
+        if selected:
+            if selected not in cookies:
+                raise ValueError('指定账号不存在或无权限访问')
+            cookie_ids = [selected]
+        else:
+            cookie_ids = list(cookies.keys())
+        if not cookie_ids:
+            raise ValueError('当前没有可同步的账号')
+
+        job.update({'status': 'running', 'message': '开始同步历史订单', 'error': None,
+                    'started_at': get_local_now().strftime('%Y-%m-%d %H:%M:%S'),
+                    'accounts_total': len(cookie_ids), 'accounts_completed': 0,
+                    'orders_discovered': 0, 'orders_processed': 0, 'orders_saved': 0,
+                    'orders_skipped': 0, 'orders_failed': 0, 'matched_orders': 0, 'warnings': []})
+
+        for account_index, cookie_id in enumerate(cookie_ids, start=1):
+            if job.get('status') == 'cancelled':
+                return
+            remaining = max_orders - int(job.get('matched_orders') or 0)
+            if remaining <= 0:
+                break
+            cookie_string = cookies.get(cookie_id)
+            if not cookie_string:
+                _history_warning(job, f'账号 {cookie_id} 缺少 Cookie，已跳过')
+                job['accounts_completed'] = account_index
+                continue
+            job['current_account'] = cookie_id
+            job['message'] = f'正在抓取账号 {cookie_id} 的历史订单列表'
+            fetcher = OrderHistoryPageFetcher(cookie_string, cookie_id_for_log=cookie_id, headless=True)
+            try:
+                try:
+                    result = await fetcher.fetch_recent_orders(max_orders=remaining, utc_start=utc_start, utc_end_exclusive=utc_end)
+                except OrderHistorySyncError as exc:
+                    warning = str(exc) + (f'；处理建议：{exc.guidance}' if exc.guidance else '')
+                    _history_warning(job, warning)
+                    job['orders_failed'] += 1
+                    job['accounts_completed'] = account_index
+                    continue
+                candidates = list(result.get('orders') or [])
+                job['orders_discovered'] += int(result.get('scanned_count') or 0)
+                job['matched_orders'] += int(result.get('matched_count') or 0)
+                job['orders_skipped'] += int(result.get('out_of_range_count') or 0)
+                if not candidates:
+                    _history_warning(job, f'账号 {cookie_id} 未抓到历史订单候选')
+                    job['accounts_completed'] = account_index
+                    continue
+                for candidate in candidates:
+                    if job.get('status') == 'cancelled':
+                        return
+                    order_id = _history_text(candidate.get('order_id'))
+                    if not order_id:
+                        continue
+                    job['current_order_id'] = order_id
+                    job['orders_processed'] += 1
+                    job['message'] = f'正在同步账号 {cookie_id} 的订单 {order_id}'
+                    saved = False
+                    if fetch_details:
+                        try:
+                            detail = await fetcher.fetch_order_detail(order_id)
+                            if detail:
+                                saved = _save_history_order_detail(cookie_id, candidate, detail)
+                        except Exception as exc:
+                            logger.warning(f'历史订单详情同步失败: {cookie_id}/{order_id}: {exc}')
+                            _history_warning(job, f'订单 {order_id} 详情刷新失败: {exc}')
+                    if not saved:
+                        saved = _save_history_order_candidate(cookie_id, candidate)
+                    if saved:
+                        job['orders_saved'] += 1
+                    else:
+                        job['orders_failed'] += 1
+                        job['orders_skipped'] += 1
+                job['accounts_completed'] = account_index
+            finally:
+                await fetcher.close()
+
+        job['status'] = 'completed'
+        job['message'] = (f"历史订单同步完成，共扫描 {job.get('orders_discovered', 0)} 单，"
+                         f"命中时间范围 {job.get('matched_orders', 0)} 单，入库/更新 {job.get('orders_saved', 0)} 单")
+    except asyncio.CancelledError:
+        job['status'] = 'cancelled'
+        job['message'] = '历史订单同步已取消'
+    except Exception as exc:
+        logger.exception(f'历史订单同步任务失败: {job_id}')
+        job['status'] = 'failed'
+        job['error'] = str(exc)
+        job['message'] = f'历史订单同步失败: {exc}'
+    finally:
+        job['current_account'] = None
+        job['current_order_id'] = None
+        job['finished_at'] = get_local_now().strftime('%Y-%m-%d %H:%M:%S')
+        job['finished_ts'] = time.time()
+
+
+@app.post('/api/orders/history-sync')
+async def start_order_history_sync(request: OrderHistorySyncRequest, current_user: Dict[str, Any] = Depends(get_current_user)):
+    """按日期范围同步历史订单；与实时 WebSocket 监控互补。"""
+    try:
+        data = request.dict()
+        start_date, end_date = str(data.get('start_date') or '').strip(), str(data.get('end_date') or '').strip()
+        if not start_date or not end_date:
+            raise HTTPException(status_code=400, detail='开始日期和结束日期不能为空')
+        _cleanup_order_history_sync_jobs()
+        job_id = f"history_sync_{secrets.token_hex(8)}"
+        job = {
+            'job_id': job_id, 'status': 'pending', 'message': '历史订单同步任务已创建，等待执行',
+            'error': None, 'created_at': get_local_now().strftime('%Y-%m-%d %H:%M:%S'),
+            'started_at': None, 'finished_at': None, 'finished_ts': None,
+            'request': {'cookie_id': _history_text(data.get('cookie_id')), 'start_date': start_date,
+                        'end_date': end_date, 'max_orders': min(max(int(data.get('max_orders') or 120), 1), 500),
+                        'fetch_details': bool(data.get('fetch_details', True))},
+            'user_id': current_user['user_id'], 'current_account': None, 'current_order_id': None,
+            'accounts_total': 0, 'accounts_completed': 0, 'orders_discovered': 0,
+            'orders_processed': 0, 'orders_saved': 0, 'orders_skipped': 0, 'orders_failed': 0,
+            'matched_orders': 0, 'warnings': [],
+        }
+        order_history_sync_jobs[job_id] = job
+        task = asyncio.create_task(_run_order_history_sync_job(job_id))
+        order_history_sync_tasks[job_id] = task
+        task.add_done_callback(lambda _: order_history_sync_tasks.pop(job_id, None))
+        return {'success': True, 'data': _history_job_snapshot(job)}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f'创建历史订单同步任务失败: {exc}')
+
+
+@app.get('/api/orders/history-sync/{job_id}')
+def get_order_history_sync_status(job_id: str, current_user: Dict[str, Any] = Depends(get_current_user)):
+    _cleanup_order_history_sync_jobs()
+    job = order_history_sync_jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail='历史订单同步任务不存在或已过期')
+    if job.get('user_id') != current_user['user_id']:
+        raise HTTPException(status_code=403, detail='无权访问该历史订单同步任务')
+    return {'success': True, 'data': _history_job_snapshot(job)}
+
+
+@app.post('/api/orders/history-sync/{job_id}/cancel')
+def cancel_order_history_sync(job_id: str, current_user: Dict[str, Any] = Depends(get_current_user)):
+    job = order_history_sync_jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail='历史订单同步任务不存在或已过期')
+    if job.get('user_id') != current_user['user_id']:
+        raise HTTPException(status_code=403, detail='无权取消该历史订单同步任务')
+    if job.get('status') not in {'completed', 'failed', 'cancelled'}:
+        job['status'] = 'cancelled'
+        job['message'] = '历史订单同步已取消'
+        task = order_history_sync_tasks.get(job_id)
+        if task and not task.done():
+            task.cancel()
+    return {'success': True, 'data': _history_job_snapshot(job)}
+
 @app.get('/api/orders')
 def get_user_orders(
     current_user: Dict[str, Any] = Depends(get_current_user),
@@ -7301,8 +7605,15 @@ def get_user_orders(
                 order['cookie_id'] = cid
                 # 添加 item_title 字段
                 order['item_title'] = item_titles.get(order.get('item_id'), '')
+                # 订单详情页在权限不足/字段缺失时会返回 unknown，不能覆盖本地已有的待发货状态。
+                # 将 fix 项目的部分发货状态映射为 Butler 前端可处理的待发货状态。
+                raw_status = str(order.get('order_status') or '').strip()
+                if raw_status in {'partial_pending_finalize', 'partial_success'}:
+                    order['status'] = 'pending_ship'
+                else:
+                    order['status'] = get_order_status(order)
                 # 状态筛选
-                if status and get_order_status(order) != status:
+                if status and order.get('status') != status:
                     continue
                 all_orders.append(order)
 
@@ -7447,6 +7758,9 @@ async def refresh_single_order(
             result.get('order_status'),
             result.get('status_text') or result.get('dom_status') or result.get('api_status'),
         )
+        # 刷新接口返回 unknown 时保留本地状态，避免一次刷新把可发货订单变成 unknown。
+        if order_status == 'unknown' and str(order.get('order_status') or '').strip() not in {'', 'unknown'}:
+            order_status = order.get('order_status')
 
         # 更新数据库
         db_manager.insert_or_update_order(
@@ -7669,6 +7983,7 @@ async def refresh_orders_status(
     try:
         from app.db_manager import db_manager
         from utils.order_fetcher_optimized import process_orders_batch
+        from app.xianyu_im import parse_conversation
 
         user_id = current_user['user_id']
         log_with_user('info', f"开始智能刷新订单状态（优化版：并发处理） (cookie_id={cookie_id}, status={status})", current_user)
@@ -7681,6 +7996,180 @@ async def refresh_orders_status(
             if cookie_id not in user_cookies:
                 raise HTTPException(status_code=404, detail="Cookie不存在或无权访问")
             user_cookies = {cookie_id: user_cookies[cookie_id]}
+
+        # The merchant sold-order endpoint is unavailable to many personal
+        # sellers.  Discover trades from recent IM conversations first; the IM
+        # trade header contains the real order id and status and is the same
+        # source used by the normal Goofish message page.
+        discovered_count = 0
+        discovery_errors = []
+        for cid in user_cookies.keys():
+            try:
+                async def discover_from_im(instance):
+                    body = await instance.get_im_conversations(None, 30)
+                    raw_conversations = body.get('userConvs', []) if isinstance(body, dict) else []
+                    semaphore = asyncio.Semaphore(3)
+
+                    async def inspect_conversation(wrapper):
+                        raw = wrapper.get('singleChatUserConversation', wrapper) if isinstance(wrapper, dict) else {}
+                        parsed = parse_conversation(raw, str(getattr(instance, 'myid', '') or ''))
+                        if not parsed or not parsed.get('cid') or not parsed.get('itemId'):
+                            return None
+                        async with semaphore:
+                            # Personal sellers have no PC "sold orders" page.
+                            # The transaction cards in normal IM history are
+                            # the authoritative fallback and include orderId.
+                            head = {}
+                            message_page = await instance.get_im_messages(parsed['cid'], None, 80)
+                            models = message_page.get('userMessageModels', []) if isinstance(message_page, dict) else []
+                            candidate_order_id = ''
+                            candidate_created_at = None
+                            history_text = ''
+                            for model in models:
+                                raw_text = json.dumps(model, ensure_ascii=False, separators=(',', ':'))
+                                encoded_values = []
+                                def collect_encoded(value):
+                                    if isinstance(value, dict):
+                                        for child in value.values():
+                                            collect_encoded(child)
+                                    elif isinstance(value, list):
+                                        for child in value:
+                                            collect_encoded(child)
+                                    elif isinstance(value, str) and len(value) >= 24:
+                                        encoded_values.append(value)
+                                collect_encoded(model)
+                                for encoded in encoded_values:
+                                    try:
+                                        decoded = base64.b64decode(encoded + '=' * (-len(encoded) % 4)).decode('utf-8')
+                                        if decoded:
+                                            raw_text += '\n' + decoded
+                                    except Exception:
+                                        pass
+                                history_text += '\n' + raw_text
+                                order_match = None
+                                for pattern in (
+                                    r'orderId(?:%3D|[=:\\"\s]+)(\d{10,})',
+                                    r'bizOrderId(?:%3D|[=:\\"\s]+)(\d{10,})',
+                                    r'order_detail(?:%3F|\?)(?:id|orderId)(?:%3D|=)(\d{10,})',
+                                ):
+                                    order_match = re.search(pattern, raw_text, re.IGNORECASE)
+                                    if order_match:
+                                        break
+                                if order_match and not candidate_order_id:
+                                    candidate_order_id = order_match.group(1)
+                                    message_obj = model.get('message', {}) if isinstance(model, dict) else {}
+                                    extension_obj = message_obj.get('extension', {}) if isinstance(message_obj, dict) else {}
+                                    timestamp_value = next(
+                                        (
+                                            value for value in (
+                                                model.get('createTime') if isinstance(model, dict) else None,
+                                                model.get('gmtCreate') if isinstance(model, dict) else None,
+                                                message_obj.get('createAt') if isinstance(message_obj, dict) else None,
+                                                message_obj.get('createTime') if isinstance(message_obj, dict) else None,
+                                                message_obj.get('time') if isinstance(message_obj, dict) else None,
+                                                extension_obj.get('createTime') if isinstance(extension_obj, dict) else None,
+                                            )
+                                            if value not in (None, '', 0, '0')
+                                        ),
+                                        None,
+                                    )
+                                    try:
+                                        timestamp_number = int(float(timestamp_value))
+                                        if timestamp_number < 10**11:
+                                            timestamp_number *= 1000
+                                        candidate_created_at = datetime.fromtimestamp(
+                                            timestamp_number / 1000,
+                                            tz=get_local_now().tzinfo,
+                                        ).strftime('%Y-%m-%d %H:%M:%S')
+                                    except (TypeError, ValueError, OSError, OverflowError):
+                                        candidate_created_at = None
+                            if candidate_order_id:
+                                # Prefer the most final event found anywhere
+                                # in this conversation, not merely in the card
+                                # that happened to contain the orderId URL.
+                                status_name = next(
+                                    (label for label in (
+                                        '退款成功', '交易关闭', '交易成功', '你已发货',
+                                        '买家已付款', '我已付款，等待你发货', '已付款，待发货', '待付款',
+                                    ) if label in history_text),
+                                    '',
+                                )
+                                head = {
+                                    'orderId': candidate_order_id,
+                                    'utArgs': {'orderStatusName': status_name},
+                                }
+                        order_id = str((head or {}).get('orderId') or '').strip()
+                        if not order_id:
+                            return None
+
+                        common_data = (head or {}).get('commonData') or {}
+                        item_pre_info = common_data.get('itemPreInfo') if isinstance(common_data, dict) else {}
+                        if isinstance(item_pre_info, str):
+                            try:
+                                item_pre_info = json.loads(item_pre_info)
+                            except Exception:
+                                item_pre_info = {}
+                        if not isinstance(item_pre_info, dict):
+                            item_pre_info = {}
+
+                        ut_args = (head or {}).get('utArgs') or {}
+                        middle = (((head or {}).get('middle') or {}).get('data') or {})
+                        status_text = ut_args.get('orderStatusName') if isinstance(ut_args, dict) else None
+                        incoming_status = {
+                            '我已付款，等待你发货': 'pending_ship',
+                            '待付款': 'pending_payment',
+                        }.get(str(status_text or '').strip()) or normalize_order_status(None, status_text)
+                        existing = db_manager.get_order_by_id(order_id) or {}
+                        existing_status = get_order_status(existing) if existing else None
+                        if incoming_status == 'unknown' and existing_status:
+                            incoming_status = existing_status
+                        if existing_status and is_stable_order_status(existing_status) and not is_stable_order_status(incoming_status):
+                            incoming_status = existing_status
+
+                        amount = middle.get('price') or item_pre_info.get('soldPrice')
+                        if amount is not None:
+                            amount_match = re.search(r'\d+(?:\.\d+)?', str(amount).replace(',', ''))
+                            amount = amount_match.group(0) if amount_match else None
+
+                        item_id_value = str(parsed.get('itemId') or '').strip()
+                        title = item_pre_info.get('title') or parsed.get('itemTitle')
+                        if item_id_value and title:
+                            db_manager.save_item_basic_info(cid, item_id_value, str(title))
+
+                        saved = db_manager.insert_or_update_order(
+                            order_id=order_id,
+                            item_id=item_id_value or None,
+                            buyer_id=str(parsed.get('otherUserId') or '').strip() or None,
+                            amount=amount,
+                            order_status=incoming_status,
+                            cookie_id=cid,
+                            created_at=candidate_created_at,
+                            chat_id=str(parsed.get('cid') or '').strip() or None,
+                        )
+                        return {
+                            'order_id': order_id,
+                            'is_new': not bool(existing),
+                            'saved': bool(saved),
+                            'status': incoming_status,
+                        }
+
+                    results = await asyncio.gather(
+                        *(inspect_conversation(item) for item in raw_conversations),
+                        return_exceptions=True,
+                    )
+                    return [result for result in results if isinstance(result, dict) and result.get('saved')]
+
+                found = await _run_on_account_loop(cid, discover_from_im)
+                new_found = sum(1 for entry in found if entry.get('is_new'))
+                discovered_count += new_found
+                log_with_user(
+                    'info',
+                    f'账号 {cid} IM订单发现完成: matched={len(found)}, new={new_found}',
+                    current_user,
+                )
+            except Exception as discovery_error:
+                discovery_errors.append(f'{cid}: {discovery_error}')
+                log_with_user('warning', f'账号 {cid} IM订单发现失败: {discovery_error}', current_user)
 
         # 获取需要刷新的订单
         orders_to_refresh = []
@@ -7710,12 +8199,18 @@ async def refresh_orders_status(
         if not orders_to_refresh:
             return JSONResponse({
                 "success": True,
-                "message": "没有需要刷新的订单",
+                "message": (
+                    f"已从最近会话补录 {discovered_count} 个订单，没有需要刷新状态的订单"
+                    if discovered_count else
+                    "没有发现新订单，也没有需要刷新状态的订单"
+                ),
                 "summary": {
                     "total": 0,
                     "updated": 0,
                     "no_change": 0,
-                    "failed": 0
+                    "failed": 0,
+                    "discovered": discovered_count,
+                    "discovery_errors": discovery_errors,
                 },
                 "results": []
             })
@@ -7774,6 +8269,8 @@ async def refresh_orders_status(
                         result.get('order_status'),
                         result.get('status_text') or dom_status or api_status,
                     )
+                    if order_status == 'unknown' and str(current_status or '').strip() not in {'', 'unknown'}:
+                        order_status = current_status
 
                     # 更新数据库
                     success = db_manager.insert_or_update_order(
@@ -7824,12 +8321,14 @@ async def refresh_orders_status(
 
         return JSONResponse({
             "success": True,
-            "message": f"刷新完成: 更新{updated_count}个, 无变化{no_change_count}个, 失败{failed_count}个",
+            "message": f"同步完成: 新发现{discovered_count}个, 更新{updated_count}个, 无变化{no_change_count}个, 失败{failed_count}个",
             "summary": {
                 "total": len(orders_to_refresh),
                 "updated": updated_count,
                 "no_change": no_change_count,
-                "failed": failed_count
+                "failed": failed_count,
+                "discovered": discovered_count,
+                "discovery_errors": discovery_errors,
             },
             "updated_orders": refresh_results
         })

--- a/app/routers/auto_rating.py
+++ b/app/routers/auto_rating.py
@@ -1,0 +1,84 @@
+from typing import Any, Callable, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.auto_rate_task import rate_order_once, run_auto_rate_batch
+
+
+class AutoRatingSettingsUpdate(BaseModel):
+    enabled: bool
+
+
+class CommentTemplateUpdate(BaseModel):
+    name: str = Field(default="默认好评", max_length=80)
+    content: str = Field(min_length=1, max_length=500)
+
+
+class ManualRateRequest(BaseModel):
+    cookie_id: str
+    comment: Optional[str] = Field(default=None, max_length=500)
+
+
+def create_auto_rating_router(get_current_user: Callable, db_manager: Any) -> APIRouter:
+    router = APIRouter(prefix="/api/auto-rating", tags=["auto-rating"])
+
+    def ensure_account(user: Dict[str, Any], cookie_id: str) -> None:
+        if cookie_id not in db_manager.get_all_cookies(user["user_id"]):
+            raise HTTPException(status_code=403, detail="无权操作该账号")
+
+    @router.get("/accounts/{cookie_id}")
+    def get_settings(cookie_id: str, user=Depends(get_current_user)):
+        ensure_account(user, cookie_id)
+        return {
+            "enabled": db_manager.get_auto_comment(cookie_id),
+            "template": db_manager.get_active_comment_template(cookie_id),
+            "templates": db_manager.get_comment_templates(cookie_id),
+        }
+
+    @router.put("/accounts/{cookie_id}")
+    def update_settings(cookie_id: str, payload: AutoRatingSettingsUpdate, user=Depends(get_current_user)):
+        ensure_account(user, cookie_id)
+        if payload.enabled and not db_manager.get_active_comment_template(cookie_id):
+            raise HTTPException(status_code=400, detail="请先保存评价模板，再开启自动评价")
+        if not db_manager.update_auto_comment(cookie_id, payload.enabled):
+            raise HTTPException(status_code=500, detail="自动评价设置保存失败")
+        return {"success": True, "enabled": payload.enabled}
+
+    @router.put("/accounts/{cookie_id}/template")
+    def save_template(cookie_id: str, payload: CommentTemplateUpdate, user=Depends(get_current_user)):
+        ensure_account(user, cookie_id)
+        template_id = db_manager.save_active_comment_template(
+            cookie_id, payload.name.strip() or "默认好评", payload.content.strip()
+        )
+        return {"success": True, "template_id": template_id,
+                "template": db_manager.get_active_comment_template(cookie_id)}
+
+    @router.post("/run")
+    async def run_once(user=Depends(get_current_user)):
+        # 调度器内部会遍历所有账号；这里显式限制为当前用户的已开启账号。
+        allowed = set(db_manager.get_all_cookies(user["user_id"]))
+        result = await run_auto_rate_batch(allowed_cookie_ids=allowed)
+        return {"success": True, "data": result}
+
+    @router.post("/orders/{order_id}")
+    async def rate_order(order_id: str, payload: ManualRateRequest, user=Depends(get_current_user)):
+        ensure_account(user, payload.cookie_id)
+        order = db_manager.get_order_by_id(order_id)
+        if not order or str(order.get("cookie_id") or "") != payload.cookie_id:
+            raise HTTPException(status_code=404, detail="订单不存在或不属于该账号")
+        result = await rate_order_once(payload.cookie_id, order_id, payload.comment, source="manual")
+        if not result.get("success"):
+            raise HTTPException(status_code=400, detail=result.get("message") or "评价失败")
+        return result
+
+    @router.get("/logs")
+    def logs(cookie_id: Optional[str] = None, limit: int = Query(50, ge=1, le=500),
+             offset: int = Query(0, ge=0), user=Depends(get_current_user)):
+        if cookie_id:
+            ensure_account(user, cookie_id)
+        return {"success": True, "data": db_manager.get_scheduled_rate_logs(
+            user_id=user["user_id"], cookie_id=cookie_id, limit=limit, offset=offset
+        )}
+
+    return router

--- a/app/services/rate_service.py
+++ b/app/services/rate_service.py
@@ -1,0 +1,427 @@
+"""闲鱼买家评价服务。
+
+本模块参考上游项目的 RateService，但适配当前单体项目结构：
+- 直接调用闲鱼 mtop.taobao.idle.rate.create 接口；
+- 不再依赖外部 auto_comment_api_url；
+- 令牌过期时尝试合并响应 Set-Cookie 并更新本地 cookies 表后重试一次。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+from typing import Any, Dict, Tuple
+
+import aiohttp
+from loguru import logger
+
+
+APP_KEY = "34839810"
+RATE_API_URL = "https://h5api.m.goofish.com/h5/mtop.taobao.idle.rate.create/4.0/"
+RATE_API_NAME = "mtop.taobao.idle.rate.create"
+MERCHANT_RATE_LIST_API_URL = "https://h5api.m.goofish.com/h5/mtop.taobao.idle.merchant.rate.list/1.0/"
+MERCHANT_RATE_LIST_API_NAME = "mtop.taobao.idle.merchant.rate.list"
+
+
+class RateService:
+    """闲鱼评价服务。"""
+
+    def __init__(self, cookie_string: str, account_id: str | None = None):
+        self.cookie_string = str(cookie_string or "").strip()
+        self.account_id = account_id
+        self.cookies_dict = self._parse_cookies(self.cookie_string)
+
+    @staticmethod
+    def _parse_cookies(cookies_str: str) -> Dict[str, str]:
+        cookies: Dict[str, str] = {}
+        for part in str(cookies_str or "").replace("\ufeff", "").split(";"):
+            part = part.strip()
+            if not part or "=" not in part:
+                continue
+            key, value = part.split("=", 1)
+            key = key.strip()
+            if key:
+                cookies[key] = value.strip()
+        return cookies
+
+    @staticmethod
+    def _cookie_dict_to_string(cookies: Dict[str, str]) -> str:
+        return "; ".join(f"{key}={value}" for key, value in cookies.items())
+
+    @staticmethod
+    def _generate_sign(t: str, token: str, data: str) -> str:
+        msg = f"{token}&{t}&{APP_KEY}&{data}"
+        md5_hash = hashlib.md5()
+        md5_hash.update(msg.encode("utf-8"))
+        return md5_hash.hexdigest()
+
+    @staticmethod
+    def _ret_to_text(ret: Any) -> str:
+        if isinstance(ret, list):
+            return "; ".join(str(item) for item in ret)
+        return str(ret or "")
+
+    @classmethod
+    def _is_token_expired(cls, ret: Any) -> bool:
+        ret_text = cls._ret_to_text(ret)
+        return "FAIL_SYS_TOKEN_EXOIRED" in ret_text or "令牌过期" in ret_text
+
+    @classmethod
+    def _is_session_expired(cls, ret: Any) -> bool:
+        ret_text = cls._ret_to_text(ret)
+        return "FAIL_SYS_SESSION_EXPIRED" in ret_text or "Session过期" in ret_text
+
+    @classmethod
+    def _is_already_rated(cls, ret: Any, result: Any) -> bool:
+        text = cls._ret_to_text(ret) + " " + json.dumps(result, ensure_ascii=False, default=str)
+        return any(keyword in text for keyword in ("已评价", "已经评价", "不能重复评价", "重复评价"))
+
+    @staticmethod
+    def _extract_set_cookies(response: aiohttp.ClientResponse) -> Dict[str, str]:
+        new_cookies: Dict[str, str] = {}
+        try:
+            for cookie_header in response.headers.getall("set-cookie", []):
+                first_part = cookie_header.split(";", 1)[0]
+                if "=" not in first_part:
+                    continue
+                name, value = first_part.split("=", 1)
+                name = name.strip()
+                if name:
+                    new_cookies[name] = value.strip()
+        except Exception as exc:
+            logger.warning(f"提取评价接口 Set-Cookie 失败: {exc}")
+        return new_cookies
+
+    def _merge_response_cookies(self, response: aiohttp.ClientResponse) -> Tuple[bool, str]:
+        new_cookies = self._extract_set_cookies(response)
+        if not new_cookies:
+            return False, self.cookie_string
+        merged = dict(self.cookies_dict)
+        merged.update(new_cookies)
+        merged_string = self._cookie_dict_to_string(merged)
+        logger.info(
+            f"【{self.account_id or '未知账号'}】评价接口返回新 Cookie，已合并 {len(new_cookies)} 个字段"
+        )
+        return True, merged_string
+
+    async def _persist_cookie_if_needed(self, new_cookie_string: str) -> None:
+        if not self.account_id or not new_cookie_string or new_cookie_string == self.cookie_string:
+            return
+        try:
+            from app.db_manager import db_manager
+
+            # 只更新 value，避免 save_cookie 的 REPLACE 语义重置账号设置并级联删除模板。
+            db_manager.update_cookie_account_info(self.account_id, cookie_value=new_cookie_string)
+            logger.info(f"【{self.account_id}】评价接口刷新后的 Cookie 已保存到数据库")
+        except Exception as exc:
+            logger.warning(f"【{self.account_id}】保存评价接口刷新 Cookie 失败: {exc}")
+
+    async def rate_buyer(self, trade_id: str, feedback: str = "不错的买家", is_retry: bool = False) -> Dict[str, Any]:
+        """评价买家。
+
+        Args:
+            trade_id: 闲鱼订单号。
+            feedback: 评价内容。
+            is_retry: token 过期后内部重试标记。
+        """
+        trade_id = str(trade_id or "").strip()
+        feedback = str(feedback or "").strip()
+        if not trade_id:
+            return {"success": False, "message": "缺少订单号"}
+        if not feedback:
+            return {"success": False, "message": "评价内容不能为空"}
+        if not self.cookie_string:
+            return {"success": False, "message": "账号 Cookie 为空"}
+
+        m_h5_tk = self.cookies_dict.get("_m_h5_tk", "")
+        token = m_h5_tk.split("_", 1)[0] if m_h5_tk else ""
+        if not token:
+            return {"success": False, "message": "Cookie 中缺少 _m_h5_tk，无法生成评价签名"}
+
+        timestamp = str(int(time.time() * 1000))
+        data_obj = {
+            "tradeId": trade_id,
+            "rate": 1,
+            "feedback": feedback,
+            "createOrAppend": 0,
+        }
+        data_val = json.dumps(data_obj, separators=(",", ":"), ensure_ascii=False)
+        sign = self._generate_sign(timestamp, token, data_val)
+
+        params = {
+            "jsv": "2.7.2",
+            "appKey": APP_KEY,
+            "t": timestamp,
+            "sign": sign,
+            "v": "4.0",
+            "type": "originaljson",
+            "accountSite": "xianyu",
+            "dataType": "json",
+            "timeout": "20000",
+            "api": RATE_API_NAME,
+            "sessionOption": "AutoLoginOnly",
+        }
+        headers = {
+            "accept": "application/json",
+            "content-type": "application/x-www-form-urlencoded",
+            "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            "referer": "https://www.goofish.com/",
+            "origin": "https://www.goofish.com",
+            "cookie": self.cookie_string,
+        }
+
+        try:
+            timeout = aiohttp.ClientTimeout(total=20)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(RATE_API_URL, params=params, headers=headers, data={"data": data_val}) as response:
+                    try:
+                        result = await response.json(content_type=None)
+                    except Exception:
+                        body = await response.text()
+                        return {
+                            "success": False,
+                            "message": f"评价接口返回非 JSON: HTTP {response.status}",
+                            "raw": body[:1000],
+                        }
+
+                    ret = result.get("ret", []) if isinstance(result, dict) else []
+                    ret_text = self._ret_to_text(ret) or str(result)
+                    retry_tag = "[令牌过期重试] " if is_retry else ""
+
+                    if "SUCCESS" in ret_text:
+                        logger.info(
+                            f"【{self.account_id or '未知账号'}】{retry_tag}评价成功: trade_id={trade_id}"
+                        )
+                        return {"success": True, "message": "评价成功", "raw": result}
+
+                    if self._is_already_rated(ret, result):
+                        logger.info(
+                            f"【{self.account_id or '未知账号'}】订单已评价，按成功处理: trade_id={trade_id}, ret={ret}"
+                        )
+                        return {"success": True, "already_rated": True, "message": "订单已评价", "raw": result}
+
+                    if not is_retry and self._is_token_expired(ret):
+                        has_new_cookie, new_cookie_string = self._merge_response_cookies(response)
+                        if has_new_cookie:
+                            await self._persist_cookie_if_needed(new_cookie_string)
+                            self.cookie_string = new_cookie_string
+                            self.cookies_dict = self._parse_cookies(new_cookie_string)
+                            return await self.rate_buyer(trade_id, feedback, is_retry=True)
+                        return {"success": False, "message": "令牌过期且响应未返回新 Cookie", "raw": result}
+
+                    if self._is_session_expired(ret):
+                        return {"success": False, "session_expired": True, "message": ret_text, "raw": result}
+
+                    logger.warning(
+                        f"【{self.account_id or '未知账号'}】{retry_tag}评价失败: trade_id={trade_id}, ret={ret}"
+                    )
+                    return {"success": False, "message": ret_text, "raw": result}
+        except asyncio.TimeoutError:  # type: ignore[name-defined]
+            return {"success": False, "message": "评价接口请求超时"}
+        except Exception as exc:
+            logger.error(f"【{self.account_id or '未知账号'}】评价异常: trade_id={trade_id}, error={exc}")
+            return {"success": False, "message": str(exc)}
+
+
+async def fetch_merchant_rate_list(
+    cookie_string: str,
+    account_id: str | None = None,
+    page: int = 1,
+    page_size: int = 20,
+    max_retries: int = 3,
+) -> Dict[str, Any]:
+    """获取商家待评价订单列表。"""
+    current_cookie = str(cookie_string or "").strip()
+    if not current_cookie:
+        return {
+            "success": False,
+            "items": [],
+            "total_count": 0,
+            "message": "账号 Cookie 为空",
+            "cookies_str": current_cookie,
+        }
+
+    safe_page = max(1, int(page or 1))
+    safe_page_size = max(1, min(int(page_size or 20), 100))
+    safe_retries = max(1, min(int(max_retries or 3), 5))
+
+    for attempt in range(safe_retries):
+        service = RateService(current_cookie, account_id=account_id)
+        token = service.cookies_dict.get("_m_h5_tk", "").split("_", 1)[0] if service.cookies_dict.get("_m_h5_tk") else ""
+        if not token:
+            return {
+                "success": False,
+                "items": [],
+                "total_count": 0,
+                "message": "Cookie 中缺少 _m_h5_tk，无法获取待评价列表",
+                "cookies_str": current_cookie,
+            }
+
+        timestamp = str(int(time.time() * 1000))
+        data_obj = {
+            "pageNumber": safe_page,
+            "rowsPerPage": safe_page_size,
+            "queryType": "ORDER",
+            "rateSearchParam": {
+                "sellerRateStatus": "5",
+            },
+        }
+        data_val = json.dumps(data_obj, separators=(",", ":"), ensure_ascii=False)
+        sign = service._generate_sign(timestamp, token, data_val)
+        params = {
+            "jsv": "2.7.2",
+            "appKey": APP_KEY,
+            "t": timestamp,
+            "sign": sign,
+            "v": "1.0",
+            "type": "json",
+            "accountSite": "xianyu",
+            "dataType": "json",
+            "timeout": "20000",
+            "api": MERCHANT_RATE_LIST_API_NAME,
+            "valueType": "string",
+            "sessionOption": "AutoLoginOnly",
+        }
+        headers = {
+            "accept": "application/json",
+            "content-type": "application/x-www-form-urlencoded",
+            "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            "referer": "https://seller.goofish.com/?site=COMMONPRO",
+            "origin": "https://seller.goofish.com",
+            "cookie": current_cookie,
+        }
+
+        try:
+            timeout = aiohttp.ClientTimeout(total=20)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(
+                    MERCHANT_RATE_LIST_API_URL,
+                    params=params,
+                    headers=headers,
+                    data={"data": data_val},
+                ) as response:
+                    try:
+                        result = await response.json(content_type=None)
+                    except Exception:
+                        body = await response.text()
+                        return {
+                            "success": False,
+                            "items": [],
+                            "total_count": 0,
+                            "message": f"待评价列表接口返回非 JSON: HTTP {response.status}",
+                            "cookies_str": current_cookie,
+                            "raw": body[:1000],
+                        }
+
+                    ret = result.get("ret", []) if isinstance(result, dict) else []
+                    ret_text = service._ret_to_text(ret) or str(result)
+
+                    if "SUCCESS" in ret_text:
+                        module = result.get("data", {}).get("module", {}) if isinstance(result, dict) else {}
+                        items = module.get("items", [])
+                        if not isinstance(items, list):
+                            items = []
+                        try:
+                            total_count = int(module.get("totalCount") or len(items) or 0)
+                        except Exception:
+                            total_count = len(items)
+                        logger.info(
+                            f"账号 {account_id or '未知'} 获取待评价列表成功: 共 {total_count} 条，本页 {len(items)} 条"
+                        )
+                        return {
+                            "success": True,
+                            "items": items,
+                            "total_count": total_count,
+                            "message": "获取成功",
+                            "cookies_str": current_cookie,
+                            "raw": result,
+                        }
+
+                    if service._is_token_expired(ret):
+                        logger.warning(
+                            f"账号 {account_id or '未知'} 获取待评价列表令牌过期 (尝试 {attempt + 1}/{safe_retries})"
+                        )
+                        has_new_cookie, new_cookie_string = service._merge_response_cookies(response)
+                        if has_new_cookie:
+                            await service._persist_cookie_if_needed(new_cookie_string)
+                            current_cookie = new_cookie_string
+                            continue
+                        if attempt < safe_retries - 1:
+                            await asyncio.sleep(1)
+                            continue
+                        return {
+                            "success": False,
+                            "items": [],
+                            "total_count": 0,
+                            "message": f"令牌过期且无法刷新: {ret_text}",
+                            "cookies_str": current_cookie,
+                            "raw": result,
+                        }
+
+                    if service._is_session_expired(ret):
+                        if account_id:
+                            try:
+                                from app.db_manager import db_manager
+
+                                db_manager.update_cookie_status_note(account_id, "Session过期，待重新登录")
+                            except Exception as mark_exc:
+                                logger.warning(f"账号 {account_id} 标记 Session 过期失败: {mark_exc}")
+                        return {
+                            "success": False,
+                            "items": [],
+                            "total_count": 0,
+                            "session_expired": True,
+                            "message": f"Session过期: {ret_text}",
+                            "cookies_str": current_cookie,
+                            "raw": result,
+                        }
+
+                    logger.warning(
+                        f"账号 {account_id or '未知'} 获取待评价列表失败 (尝试 {attempt + 1}/{safe_retries}): {ret_text}"
+                    )
+                    if attempt < safe_retries - 1:
+                        await asyncio.sleep(1)
+                        continue
+                    return {
+                        "success": False,
+                        "items": [],
+                        "total_count": 0,
+                        "message": ret_text,
+                        "cookies_str": current_cookie,
+                        "raw": result,
+                    }
+        except asyncio.TimeoutError:  # type: ignore[name-defined]
+            if attempt < safe_retries - 1:
+                await asyncio.sleep(1)
+                continue
+            return {
+                "success": False,
+                "items": [],
+                "total_count": 0,
+                "message": "获取待评价列表请求超时",
+                "cookies_str": current_cookie,
+            }
+        except Exception as exc:
+            logger.error(
+                f"账号 {account_id or '未知'} 获取待评价列表异常 (尝试 {attempt + 1}/{safe_retries}): {exc}"
+            )
+            if attempt < safe_retries - 1:
+                await asyncio.sleep(1)
+                continue
+            return {
+                "success": False,
+                "items": [],
+                "total_count": 0,
+                "message": str(exc),
+                "cookies_str": current_cookie,
+            }
+
+    return {
+        "success": False,
+        "items": [],
+        "total_count": 0,
+        "message": "重试次数已用尽",
+        "cookies_str": current_cookie,
+    }

--- a/frontend/components/AccountList.tsx
+++ b/frontend/components/AccountList.tsx
@@ -15,17 +15,21 @@ import {
   updateAccountAISettings,
   getAllAISettings,
   getAccountAISettings,
-  refreshAccountProfile
+  refreshAccountProfile,
+  getAutoRatingSettings,
+  updateAutoRatingSettings,
+  saveAutoRatingTemplate,
+  runAutoRatingNow
 } from '../services/api';
 import { confirmAction, notify } from '../services/feedback';
 import {
   Power, Edit2, Trash2, QrCode, X, Check, Loader2,
   MessageSquare, RefreshCw, Save, User, Clock, MessageCircle,
-  Key, Eye, EyeOff, Bot, Settings, MapPin, Users
+  Key, Eye, EyeOff, Bot, Settings, MapPin, Users, Star
 } from 'lucide-react';
 import { EmptyState, PageHeader, PageLoading } from './ui';
 
-type ModalType = 'edit' | 'ai-settings' | null;
+type ModalType = 'edit' | 'ai-settings' | 'auto-rating' | null;
 
 const AccountList: React.FC = () => {
   const [accounts, setAccounts] = useState<AccountDetail[]>([]);
@@ -65,6 +69,11 @@ const AccountList: React.FC = () => {
     custom_prompts: '',
   });
   const [saving, setSaving] = useState(false);
+  const [ratingForm, setRatingForm] = useState({
+    enabled: false,
+    name: '默认好评',
+    content: '不错的买家，沟通愉快，期待再次交易！',
+  });
 
   const loadAccounts = async () => {
     setLoading(true);
@@ -171,6 +180,52 @@ const AccountList: React.FC = () => {
       setSaving(false);
     }
     setActiveModal('ai-settings');
+  };
+
+  const openAutoRatingModal = async (account: AccountDetail) => {
+    setEditingAccount(account);
+    setSaving(true);
+    try {
+      const settings = await getAutoRatingSettings(account.id);
+      setRatingForm({
+        enabled: settings.enabled,
+        name: settings.template?.name || '默认好评',
+        content: settings.template?.content || '不错的买家，沟通愉快，期待再次交易！',
+      });
+    } catch (error) {
+      notify(error instanceof Error ? error.message : '自动评价设置加载失败');
+    } finally {
+      setSaving(false);
+    }
+    setActiveModal('auto-rating');
+  };
+
+  const handleSaveAutoRating = async () => {
+    if (!editingAccount || !ratingForm.content.trim()) return;
+    setSaving(true);
+    try {
+      await saveAutoRatingTemplate(editingAccount.id, ratingForm.name, ratingForm.content);
+      await updateAutoRatingSettings(editingAccount.id, ratingForm.enabled);
+      setActiveModal(null);
+      notify('自动评价设置已保存');
+    } catch (error) {
+      notify(error instanceof Error ? error.message : '自动评价设置保存失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRunAutoRating = async () => {
+    setSaving(true);
+    try {
+      const result = await runAutoRatingNow();
+      const stats = result?.data || {};
+      notify(`执行完成：成功 ${stats.success || 0}，失败 ${stats.failed || 0}，跳过 ${stats.skipped || 0}`);
+    } catch (error) {
+      notify(error instanceof Error ? error.message : '自动评价执行失败');
+    } finally {
+      setSaving(false);
+    }
   };
 
   const handleSaveEdit = async () => {
@@ -448,6 +503,14 @@ const AccountList: React.FC = () => {
                     title="AI设置"
                 >
                     <Bot className="w-5 h-5" />
+                </button>
+                <button
+                    onClick={() => openAutoRatingModal(account)}
+                    className="rounded-md p-2.5 text-orange-600 hover:bg-orange-50"
+                    title="自动评价"
+                    aria-label="自动评价"
+                >
+                    <Star className="w-5 h-5" />
                 </button>
                 <button
                     onClick={() => handleToggle(account.id, account.enabled)}
@@ -871,6 +934,68 @@ const AccountList: React.FC = () => {
                 >
                   {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
                   {saving ? '保存中...' : '保存'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+
+      {activeModal === 'auto-rating' && editingAccount && createPortal(
+        <div className="modal-overlay">
+          <div className="modal-container" style={{maxWidth: '600px'}}>
+            <div className="modal-header flex items-start justify-between gap-4">
+              <div>
+                <h3 className="flex items-center gap-2 text-lg font-bold text-gray-900">
+                  <Star className="h-5 w-5 text-orange-500" /> 自动评价
+                </h3>
+                <p className="mt-1 text-xs text-gray-500">订单完成后自动给买家好评；默认每 5 分钟检查一次。</p>
+              </div>
+              <button type="button" onClick={() => setActiveModal(null)} className="rounded-md p-2 hover:bg-gray-100">
+                <X className="h-5 w-5 text-gray-500" />
+              </button>
+            </div>
+            <div className="modal-body space-y-5">
+              <div className="flex items-center justify-between gap-4 rounded-md border border-gray-200 bg-gray-50 p-4">
+                <div>
+                  <div className="font-bold text-gray-900">启用自动评价</div>
+                  <div className="mt-1 text-xs text-gray-500">仅处理近 10 天、状态为交易完成且尚未评价的本地订单。</div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setRatingForm({...ratingForm, enabled: !ratingForm.enabled})}
+                  className={`relative h-6 w-11 shrink-0 rounded-full transition-colors ${ratingForm.enabled ? 'bg-[#FFE815]' : 'bg-gray-300'}`}
+                >
+                  <span className={`absolute left-1 top-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${ratingForm.enabled ? 'translate-x-5' : ''}`} />
+                </button>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-bold text-gray-700">模板名称</label>
+                <input className="ios-input w-full rounded-md px-3 py-2.5" value={ratingForm.name}
+                  onChange={(event) => setRatingForm({...ratingForm, name: event.target.value})} maxLength={80} />
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-bold text-gray-700">评价内容</label>
+                <textarea className="ios-input h-28 w-full resize-y rounded-md px-3 py-2.5" value={ratingForm.content}
+                  onChange={(event) => setRatingForm({...ratingForm, content: event.target.value})} maxLength={500} />
+                <p className="mt-1 text-xs text-gray-500">{ratingForm.content.length}/500 字</p>
+              </div>
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs leading-5 text-amber-900">
+                自动评价会直接调用闲鱼评价接口，无法撤回。建议先保存但保持关闭，确认模板后再启用。
+              </div>
+            </div>
+            <div className="modal-footer">
+              <div className="flex w-full flex-wrap gap-2">
+                <button type="button" onClick={handleRunAutoRating} disabled={saving || !ratingForm.enabled}
+                  className="ios-btn-secondary flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm disabled:opacity-50">
+                  <RefreshCw className={`h-4 w-4 ${saving ? 'animate-spin' : ''}`} /> 立即检查
+                </button>
+                <button type="button" onClick={() => setActiveModal(null)} disabled={saving}
+                  className="ios-btn-secondary flex-1 rounded-md px-4 py-2.5 text-sm">取消</button>
+                <button type="button" onClick={handleSaveAutoRating} disabled={saving || !ratingForm.content.trim()}
+                  className="ios-btn-primary flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm disabled:opacity-50">
+                  {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />} 保存
                 </button>
               </div>
             </div>

--- a/frontend/components/OrderList.tsx
+++ b/frontend/components/OrderList.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Order, OrderStatus, Item } from '../types';
-import { getOrders, syncOrders, syncSingleOrder, manualShipOrder, updateOrder, deleteOrder, importOrders, getItems } from '../services/api';
+import { getOrders, syncOrders, syncSingleOrder, manualShipOrder, updateOrder, deleteOrder, importOrders, getItems, startOrderHistorySync, getOrderHistorySyncStatus, cancelOrderHistorySync, OrderHistorySyncJob } from '../services/api';
 import { confirmAction, notify } from '../services/feedback';
 import { Search, Truck, RefreshCw, ChevronLeft, ChevronRight, PackageCheck, Edit, Eye, Plus, Save, X, ExternalLink, Trash2, ClipboardList } from 'lucide-react';
 import { EmptyState, PageHeader, PageTabs } from './ui';
@@ -54,6 +54,32 @@ const OrderList: React.FC = () => {
   const [shipResult, setShipResult] = useState<{success: boolean; message: string} | null>(null);
   const [syncingOrderId, setSyncingOrderId] = useState<string | null>(null);
   const [deletingOrderId, setDeletingOrderId] = useState<string | null>(null);
+  const defaultEndDate = new Date().toISOString().slice(0, 10);
+  const defaultStartDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const [showHistorySyncModal, setShowHistorySyncModal] = useState(false);
+  const [historyStartDate, setHistoryStartDate] = useState(defaultStartDate);
+  const [historyEndDate, setHistoryEndDate] = useState(defaultEndDate);
+  const [historyMaxOrders, setHistoryMaxOrders] = useState(120);
+  const [historyFetchDetails, setHistoryFetchDetails] = useState(true);
+  const [historyJob, setHistoryJob] = useState<OrderHistorySyncJob | null>(null);
+
+  useEffect(() => {
+    if (!historyJob || !['pending', 'running'].includes(historyJob.status)) return;
+    const timer = window.setInterval(async () => {
+      try {
+        const result = await getOrderHistorySyncStatus(historyJob.job_id);
+        setHistoryJob(result.data);
+        if (['completed', 'failed', 'cancelled'].includes(result.data.status)) {
+          if (result.data.status === 'completed') notify(result.data.message || '历史订单同步完成');
+          else if (result.data.status === 'failed') notify(result.data.error || result.data.message || '历史订单同步失败');
+          await loadOrders();
+        }
+      } catch (error) {
+        console.error('查询历史订单同步状态失败:', error);
+      }
+    }, 1500);
+    return () => window.clearInterval(timer);
+  }, [historyJob?.job_id, historyJob?.status]);
 
   // 搜索过滤订单
   const filterOrders = (ordersToFilter: Order[]): Order[] => {
@@ -170,6 +196,34 @@ const OrderList: React.FC = () => {
       setLoading(true);
       await syncOrders();
       loadOrders();
+  };
+
+  const handleStartHistorySync = async () => {
+    if (!historyStartDate || !historyEndDate || historyStartDate >= historyEndDate) {
+      notify('请选择有效的日期范围（结束日期应晚于开始日期）');
+      return;
+    }
+    try {
+      const result = await startOrderHistorySync({
+        start_date: historyStartDate,
+        end_date: historyEndDate,
+        max_orders: historyMaxOrders,
+        fetch_details: historyFetchDetails,
+      });
+      setHistoryJob(result.data);
+    } catch (error: any) {
+      notify(error?.message || '创建历史订单同步任务失败');
+    }
+  };
+
+  const handleCancelHistorySync = async () => {
+    if (!historyJob) return;
+    try {
+      const result = await cancelOrderHistorySync(historyJob.job_id);
+      setHistoryJob(result.data);
+    } catch (error: any) {
+      notify(error?.message || '取消同步失败');
+    }
   };
 
   const handleShip = (id: string) => {
@@ -323,6 +377,10 @@ const OrderList: React.FC = () => {
             <button onClick={handleSync} className="ios-btn-primary flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm">
                 <Truck className="h-4 w-4" />
                 同步订单
+            </button>
+            <button onClick={() => setShowHistorySyncModal(true)} className="ios-btn-secondary flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm">
+                <ClipboardList className="h-4 w-4" />
+                历史同步
             </button>
           </>
         )}
@@ -927,6 +985,59 @@ const OrderList: React.FC = () => {
                   <Save className="w-4 h-4" />
                   保存更改
                 </button>
+              </div>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+
+      {showHistorySyncModal && createPortal(
+        <div className="modal-overlay">
+          <div className="modal-container">
+            <div className="modal-header">
+              <div className="flex w-full items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-lg font-bold text-gray-900">同步历史订单</h3>
+                  <p className="mt-1 text-xs text-gray-500">从闲鱼卖家中心补录订单；实时监控仍由账号连接负责。</p>
+                </div>
+                <button type="button" onClick={() => setShowHistorySyncModal(false)} className="rounded-md p-2 hover:bg-gray-100" aria-label="关闭历史同步">
+                  <X className="w-5 h-5 text-gray-600" />
+                </button>
+              </div>
+            </div>
+            <div className="modal-body space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <label className="block text-sm font-bold text-gray-700">开始日期
+                  <input type="date" value={historyStartDate} onChange={(e) => setHistoryStartDate(e.target.value)} className="ios-input mt-2 w-full rounded-md px-3 py-2.5" />
+                </label>
+                <label className="block text-sm font-bold text-gray-700">结束日期（不含）
+                  <input type="date" value={historyEndDate} onChange={(e) => setHistoryEndDate(e.target.value)} className="ios-input mt-2 w-full rounded-md px-3 py-2.5" />
+                </label>
+              </div>
+              <label className="block text-sm font-bold text-gray-700">最多同步订单数
+                <input type="number" min={1} max={500} value={historyMaxOrders} onChange={(e) => setHistoryMaxOrders(Math.max(1, Math.min(500, Number(e.target.value) || 1)))} className="ios-input mt-2 w-full rounded-md px-3 py-2.5" />
+              </label>
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input type="checkbox" checked={historyFetchDetails} onChange={(e) => setHistoryFetchDetails(e.target.checked)} />
+                同步订单详情（更完整，但速度较慢）
+              </label>
+              {historyJob && (
+                <div className={`rounded-md border p-3 text-sm ${historyJob.status === 'failed' ? 'border-red-200 bg-red-50 text-red-800' : 'border-blue-200 bg-blue-50 text-blue-800'}`}>
+                  <div className="font-semibold">{historyJob.message || historyJob.status}</div>
+                  <div className="mt-1 text-xs">已处理 {historyJob.orders_processed || 0} / 命中 {historyJob.matched_orders || 0} / 入库 {historyJob.orders_saved || 0}</div>
+                  {(historyJob.warnings || []).slice(0, 3).map((warning, index) => <div key={index} className="mt-1 text-xs">{warning}</div>)}
+                </div>
+              )}
+            </div>
+            <div className="modal-footer">
+              <div className="flex w-full gap-2">
+                <button type="button" onClick={() => setShowHistorySyncModal(false)} className="ios-btn-secondary flex-1 rounded-md px-4 py-2.5 text-sm">关闭</button>
+                {historyJob && ['pending', 'running'].includes(historyJob.status) ? (
+                  <button type="button" onClick={handleCancelHistorySync} className="ios-btn-secondary flex-1 rounded-md px-4 py-2.5 text-sm">取消同步</button>
+                ) : (
+                  <button type="button" onClick={handleStartHistorySync} className="ios-btn-primary flex-1 rounded-md px-4 py-2.5 text-sm">开始同步</button>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -9,7 +9,7 @@ import {
   MessageFilter, MessageFilterType, AutoReplyLog
   , ChatAccount, ChatConversation, ChatMessage, ProductMaterial,
   ProductFilterRule, ProductDeleteRule, AutomationTaskRun,
-  ProductAutomationResult, ProductDeletePreview
+  ProductAutomationResult, ProductDeletePreview, AutoRatingSettings
 } from '../types';
 
 // Auth
@@ -93,6 +93,22 @@ export const updateAccountAutoConfirm = async (id: string, autoConfirm: boolean)
   return put(`/cookies/${id}/auto-confirm`, { auto_confirm: autoConfirm });
 };
 
+export const getAutoRatingSettings = async (id: string): Promise<AutoRatingSettings> => {
+  return get(`/api/auto-rating/accounts/${id}`);
+};
+
+export const updateAutoRatingSettings = async (id: string, enabled: boolean): Promise<any> => {
+  return put(`/api/auto-rating/accounts/${id}`, { enabled });
+};
+
+export const saveAutoRatingTemplate = async (id: string, name: string, content: string): Promise<any> => {
+  return put(`/api/auto-rating/accounts/${id}/template`, { name, content });
+};
+
+export const runAutoRatingNow = async (): Promise<any> => {
+  return post('/api/auto-rating/run', {});
+};
+
 export const updateAccountPauseDuration = async (id: string, pauseDuration: number): Promise<any> => {
   return put(`/cookies/${id}/pause-duration`, { pause_duration: pauseDuration });
 };
@@ -115,7 +131,11 @@ export const getAllAISettings = async (): Promise<Record<string, AIReplySettings
 
 // Orders
 const normalizeOrder = (order: any): Order => {
-  const normalizedStatus = order?.order_status || order?.status || 'processing';
+  const rawStatus = order?.status || order?.order_status || 'processing';
+  // fix 项目中的部分发货状态在 Butler 中按“待发货”展示，仍可进入手动发货流程。
+  const normalizedStatus = ['partial_pending_finalize', 'partial_success'].includes(rawStatus)
+    ? 'pending_ship'
+    : rawStatus;
   return {
     ...order,
     status: normalizedStatus,
@@ -183,6 +203,45 @@ export const syncOrders = async (cookieId?: string, status?: string): Promise<an
 
 export const syncSingleOrder = async (orderId: string): Promise<any> => {
   return post(`/api/orders/${orderId}/refresh`);
+};
+
+export interface OrderHistorySyncRequest {
+  cookie_id?: string;
+  start_date: string;
+  end_date: string;
+  max_orders?: number;
+  fetch_details?: boolean;
+}
+
+export interface OrderHistorySyncJob {
+  job_id: string;
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+  message?: string;
+  error?: string;
+  request?: OrderHistorySyncRequest;
+  current_account?: string;
+  current_order_id?: string;
+  accounts_total?: number;
+  accounts_completed?: number;
+  orders_discovered?: number;
+  orders_processed?: number;
+  orders_saved?: number;
+  orders_skipped?: number;
+  orders_failed?: number;
+  matched_orders?: number;
+  warnings?: string[];
+}
+
+export const startOrderHistorySync = async (data: OrderHistorySyncRequest): Promise<{ success: boolean; data: OrderHistorySyncJob }> => {
+  return post('/api/orders/history-sync', data);
+};
+
+export const getOrderHistorySyncStatus = async (jobId: string): Promise<{ success: boolean; data: OrderHistorySyncJob }> => {
+  return get(`/api/orders/history-sync/${jobId}`);
+};
+
+export const cancelOrderHistorySync = async (jobId: string): Promise<{ success: boolean; data: OrderHistorySyncJob }> => {
+  return post(`/api/orders/history-sync/${jobId}/cancel`, {});
 };
 
 export const manualShipOrder = async (orderIds: string[], shipMode: 'status_only' | 'full_delivery', content?: string): Promise<any> => {

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -32,6 +32,7 @@ export interface AccountDetail {
   cookie?: string; // alias for value
   enabled: boolean;
   auto_confirm: boolean;
+  auto_comment?: boolean;
   remark?: string;
   note?: string; // alias for remark
   pause_duration?: number;
@@ -54,6 +55,19 @@ export interface AccountDetail {
   max_discount_amount?: number;
   max_bargain_rounds?: number;
   custom_prompts?: string;
+}
+
+export interface CommentTemplate {
+  id: number;
+  name: string;
+  content: string;
+  is_active: boolean;
+}
+
+export interface AutoRatingSettings {
+  enabled: boolean;
+  template?: CommentTemplate | null;
+  templates?: CommentTemplate[];
 }
 
 // Orders

--- a/tests/test_order_event_snapshot.py
+++ b/tests/test_order_event_snapshot.py
@@ -19,6 +19,34 @@ class OrderEventSnapshotTests(unittest.TestCase):
             "pending_ship",
         )
 
+    def test_new_rating_prompt_marks_order_completed(self):
+        message = {
+            "1": {
+                "10": {
+                    "reminderContent": "快给ta一个评价吧～",
+                },
+            },
+        }
+
+        self.assertEqual(XianyuLive._extract_order_event_status(message), "completed")
+
+    def test_red_reminder_marks_order_completed(self):
+        message = {
+            "1": {
+                "10": {
+                    "reminderContent": "[我完成了评价]",
+                    "redReminder": "交易成功",
+                },
+            },
+        }
+
+        self.assertEqual(XianyuLive._extract_order_event_status(message), "completed")
+        self.assertTrue(XianyuLive._is_rate_completion_event(message))
+
+    def test_rating_prompt_is_not_completion_receipt(self):
+        message = {"1": {"10": {"reminderContent": "快给ta一个评价吧～"}}}
+        self.assertFalse(XianyuLive._is_rate_completion_event(message))
+
     def test_saves_snapshot_when_order_detail_is_unavailable(self):
         fake_db = Mock()
         fake_db.get_item_info.return_value = {"item_price": "¥0.01"}

--- a/utils/browser_pool.py
+++ b/utils/browser_pool.py
@@ -215,23 +215,9 @@ class BrowserPool:
             # 创建页面
             page = await context.new_page()
 
-            # 设置额外的HTTP头
-            headers = {
-                "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
-                "accept-language": "en,zh-CN;q=0.9,zh;q=0.8,ru;q=0.7",
-                "cache-control": "no-cache",
-                "pragma": "no-cache",
-                "priority": "u=0, i",
-                "sec-ch-ua": "\"Not)A;Brand\";v=\"8\", \"Chromium\";v=\"138\", \"Google Chrome\";v=\"138\"",
-                "sec-ch-ua-mobile": "?0",
-                "sec-ch-ua-platform": "\"Windows\"",
-                "sec-fetch-dest": "document",
-                "sec-fetch-mode": "navigate",
-                "sec-fetch-site": "same-origin",
-                "sec-fetch-user": "?1",
-                "upgrade-insecure-requests": "1"
-            }
-            await context.set_extra_http_headers(headers)
+            # 不要手工伪造 sec-fetch-* / sec-ch-ua。浏览器会根据每个请求自动生成；
+            # 固定写成 same-origin 会让从空白页进入订单详情时请求上下文不一致，
+            # 闲鱼页面随后只返回空壳，订单金额和商品信息都无法渲染。
 
             # 等待浏览器完全初始化
             await asyncio.sleep(1)

--- a/utils/order_fetcher_optimized.py
+++ b/utils/order_fetcher_optimized.py
@@ -148,29 +148,20 @@ class OrderFetcherOptimized:
                 # 重置API响应列表
                 self.api_responses = []
 
-                # 设置路由拦截器（拦截API响应）
-                async def handle_route(route, request):
-                    """拦截网络请求"""
-                    # 拦截订单详情API
-                    if 'mtop.idle.web.trade.order.detail' in request.url:
-                        logger.info(f"[拦截] 发现订单详情API请求")
+                # 被动监听响应，不能用 route.fetch() 后再 route.continue()：那会让同一请求
+                # 执行两次，并可能导致订单详情页关键接口渲染失败，最终金额为空。
+                async def handle_response(response):
+                    if 'mtop.idle.web.trade.order.detail' not in response.url:
+                        return
+                    logger.info("[监听] 发现订单详情API响应")
+                    try:
+                        result = await response.json()
+                        self.api_responses.append(result)
+                        logger.info("[监听] API响应已保存")
+                    except Exception as e:
+                        logger.warning(f"解析订单详情API响应失败: {e}")
 
-                        # 继续请求并获取响应
-                        response = await route.fetch()
-                        body = await response.body()
-
-                        try:
-                            result = json.loads(body)
-                            self.api_responses.append(result)
-                            logger.info(f"[拦截] API响应已保存")
-                        except Exception as e:
-                            logger.error(f"解析API响应失败: {e}")
-
-                    # 继续所有请求
-                    await route.continue_()
-
-                # 设置路由拦截
-                await self.page.route('**/*', handle_route)
+                self.page.on('response', handle_response)
 
                 # 访问订单详情页面
                 url = f"https://www.goofish.com/order-detail?orderId={order_id}&role=seller"
@@ -188,6 +179,12 @@ class OrderFetcherOptimized:
                 # 等待API响应和页面渲染
                 logger.info("等待API响应和页面渲染...")
                 await asyncio.sleep(2)
+
+                # 当前页面为异步渲染；明确等待成交价，比固定延迟更可靠。
+                try:
+                    await self.page.wait_for_selector('[class*="boldNum"]', timeout=10000)
+                except Exception:
+                    logger.warning("等待订单成交价元素超时，将继续尝试API及DOM兜底解析")
 
                 # 快速滚动，触发延迟加载的内容
                 await self.page.evaluate('window.scrollTo(0, document.body.scrollHeight)')

--- a/utils/order_history_sync.py
+++ b/utils/order_history_sync.py
@@ -1,0 +1,503 @@
+import json
+import time
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+from loguru import logger
+
+from utils.order_detail_fetcher import OrderDetailFetcher
+from utils.time_utils import parse_db_timestamp, parse_local_datetime_text_to_db_utc
+from utils.xianyu_utils import generate_sign, trans_cookies
+
+
+ORDER_LIST_API_URL = 'https://h5api.m.goofish.com/h5/mtop.taobao.idle.trade.merchant.sold.get/1.0/'
+ORDER_LIST_API_NAME = 'mtop.taobao.idle.trade.merchant.sold.get'
+ORDER_LIST_REFERER = 'https://seller.goofish.com/?site=COMMONPRO#/seller-trade/order-manage'
+ORDER_LIST_QUERY_CODE = 'ALL'
+DEFAULT_PAGE_SIZE = 20
+ORDER_HISTORY_ANCHOR_FIELDS = (
+    'platform_paid_at',
+    'platform_created_at',
+    'platform_completed_at',
+)
+
+ORDER_STATUS_ALIASES = {
+    'processing': 'processing',
+    'pending_payment': 'pending_payment',
+    'pending_ship': 'pending_ship',
+    'partial_success': 'partial_success',
+    'partial_pending_finalize': 'partial_pending_finalize',
+    'shipped': 'shipped',
+    'completed': 'completed',
+    'refunding': 'refunding',
+    'refund_cancelled': 'refund_cancelled',
+    'cancelled': 'cancelled',
+    'unknown': 'unknown',
+    '处理中': 'processing',
+    '待付款': 'pending_payment',
+    '待发货': 'pending_ship',
+    '部分发货': 'partial_success',
+    '部分待收尾': 'partial_pending_finalize',
+    '已发货': 'shipped',
+    '交易成功': 'completed',
+    '已完成': 'completed',
+    '退款中': 'refunding',
+    '退款撤销': 'refund_cancelled',
+    '交易关闭': 'cancelled',
+    '已关闭': 'cancelled',
+}
+
+
+def normalize_order_history_status(value: Any) -> Optional[str]:
+    text = str(value or '').strip()
+    if not text:
+        return None
+
+    normalized = ORDER_STATUS_ALIASES.get(text)
+    if normalized:
+        return normalized
+
+    return ORDER_STATUS_ALIASES.get(text.lower())
+
+
+class OrderHistorySyncError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        kind: str = 'api_error',
+        ret_value: Any = None,
+        guidance: str = '',
+    ):
+        super().__init__(message)
+        self.kind = kind
+        self.ret_value = ret_value
+        self.guidance = guidance
+
+
+def _ret_value_to_text(ret_value: Any) -> str:
+    if isinstance(ret_value, str):
+        return ret_value
+    if isinstance(ret_value, (list, tuple)):
+        return ' | '.join(str(item) for item in ret_value)
+    if isinstance(ret_value, dict):
+        try:
+            return json.dumps(ret_value, ensure_ascii=False)
+        except Exception:
+            return str(ret_value)
+    return str(ret_value or '')
+
+
+def classify_order_history_api_error(ret_value: Any, cookie_id: str = 'unknown') -> OrderHistorySyncError:
+    ret_text = _ret_value_to_text(ret_value)
+    ret_text_lower = ret_text.lower()
+    account_label = cookie_id or 'unknown'
+
+    session_keywords = (
+        '令牌过期',
+        'session过期',
+        'session expired',
+        'FAIL_SYS_USER_VALIDATE',
+        'FAIL_SYS_TOKEN_EXPIRED',
+        'FAIL_SYS_TOKEN_EXOIRED',
+        'FAIL_SYS_SESSION_EXPIRED',
+        'passport.goofish.com',
+        'mini_login',
+        'login',
+    )
+    permission_keywords = (
+        'PERMISSION_EXCEPTION',
+        '无权限访问',
+        'permission denied',
+        'permission',
+    )
+
+    if any(keyword.lower() in ret_text_lower for keyword in session_keywords):
+        guidance = '请先对该账号执行手动刷新 Cookie 或重新扫码登录；若仍失败，导入浏览器中人工登录后的完整 Cookie 后再同步。'
+        return OrderHistorySyncError(
+            f'【{account_label}】历史订单列表 Cookie/Session 已过期，无法同步历史订单。平台返回: {ret_text}',
+            kind='session_expired',
+            ret_value=ret_value,
+            guidance=guidance,
+        )
+
+    if any(keyword.lower() in ret_text_lower for keyword in permission_keywords):
+        guidance = '请确认该账号可以在闲鱼/鱼店长卖家中心打开订单管理页；如果网页端也无权限，该接口无法由程序侧修复。'
+        return OrderHistorySyncError(
+            f'【{account_label}】账号暂无订单列表访问权限，无法同步历史订单。平台返回: {ret_text}',
+            kind='permission_denied',
+            ret_value=ret_value,
+            guidance=guidance,
+        )
+
+    return OrderHistorySyncError(
+        f'【{account_label}】历史订单列表 API 调用失败: {ret_text}',
+        kind='api_error',
+        ret_value=ret_value,
+        guidance='请稍后重试；如果持续失败，请查看日志中的平台返回值和账号 Cookie 状态。',
+    )
+
+
+def normalize_history_amount(value: Any) -> Optional[str]:
+    text = str(value or '').strip()
+    if not text:
+        return None
+
+    cleaned = text.replace('¥', '').replace('￥', '').replace(',', '').strip()
+    try:
+        return f"{float(cleaned):.2f}"
+    except (TypeError, ValueError):
+        return None
+
+
+def resolve_order_history_anchor_time(candidate: Dict[str, Any]) -> Optional[str]:
+    if not isinstance(candidate, dict):
+        return None
+
+    for field_name in ORDER_HISTORY_ANCHOR_FIELDS:
+        value = str(candidate.get(field_name) or '').strip()
+        if value:
+            return value
+    return None
+
+
+def classify_order_history_range(
+    anchor_time: Optional[str],
+    utc_start: Optional[str] = None,
+    utc_end_exclusive: Optional[str] = None,
+) -> str:
+    if not utc_start or not utc_end_exclusive:
+        return 'in_range'
+
+    anchor_dt = parse_db_timestamp(anchor_time) if anchor_time else None
+    start_dt = parse_db_timestamp(utc_start)
+    end_dt = parse_db_timestamp(utc_end_exclusive)
+    if not anchor_dt or not start_dt or not end_dt:
+        return 'unknown'
+    if anchor_dt < start_dt:
+        return 'before'
+    if anchor_dt >= end_dt:
+        return 'after'
+    return 'in_range'
+
+
+def _cookie_dict_to_string(cookies_dict: Dict[str, str]) -> str:
+    return '; '.join(
+        f'{name}={value}'
+        for name, value in cookies_dict.items()
+        if str(name).strip() and value is not None
+    )
+
+
+def _extract_set_cookie_updates(response_headers) -> Dict[str, str]:
+    try:
+        set_cookie_values = response_headers.getall('Set-Cookie', [])
+    except Exception:
+        raw_value = response_headers.get('Set-Cookie')
+        if isinstance(raw_value, list):
+            set_cookie_values = raw_value
+        elif raw_value:
+            set_cookie_values = [raw_value]
+        else:
+            set_cookie_values = []
+
+    updates: Dict[str, str] = {}
+    for cookie in set_cookie_values:
+        if '=' not in cookie:
+            continue
+        try:
+            name, value = cookie.split(';', 1)[0].split('=', 1)
+        except ValueError:
+            continue
+        updates[name.strip()] = value.strip()
+    return updates
+
+
+class OrderHistoryPageFetcher:
+    def __init__(self, cookie_string: str, cookie_id_for_log: str = 'unknown', headless: bool = True):
+        self.cookie_id_for_log = cookie_id_for_log or 'unknown'
+        self.headless = headless
+        self.cookie_string = str(cookie_string or '').strip()
+        self.cookies: Dict[str, str] = trans_cookies(self.cookie_string) if self.cookie_string else {}
+        self.fetcher = OrderDetailFetcher(self.cookie_string, headless=headless)
+        self.session: Optional[aiohttp.ClientSession] = None
+
+    def _is_auth_failure_ret(self, ret_value: Any) -> bool:
+        return classify_order_history_api_error(ret_value, self.cookie_id_for_log).kind == 'session_expired'
+
+    def _set_runtime_cookie_state(self, cookies_dict: Dict[str, str]) -> bool:
+        normalized = {str(name): str(value) for name, value in cookies_dict.items() if str(name).strip()}
+        new_cookie_string = _cookie_dict_to_string(normalized)
+        if new_cookie_string == self.cookie_string:
+            return False
+
+        self.cookies = normalized
+        self.cookie_string = new_cookie_string
+        self.fetcher.cookie = new_cookie_string
+        return True
+
+    async def _persist_cookie_update(self) -> None:
+        if not self.cookie_string or self.cookie_id_for_log == 'unknown':
+            return
+
+        try:
+            from app.db_manager import db_manager
+
+            db_manager.update_cookie_account_info(self.cookie_id_for_log, cookie_value=self.cookie_string)
+        except Exception as exc:
+            logger.warning(f"【{self.cookie_id_for_log}】保存刷新后的 Cookie 失败: {exc}")
+
+    async def _apply_response_cookie_updates(self, response_headers) -> bool:
+        updates = _extract_set_cookie_updates(response_headers)
+        if not updates:
+            return False
+
+        merged_cookies = dict(self.cookies)
+        merged_cookies.update(updates)
+        changed = self._set_runtime_cookie_state(merged_cookies)
+        if changed:
+            await self._persist_cookie_update()
+        return changed
+
+    async def _ensure_session(self) -> None:
+        if self.session and not self.session.closed:
+            return
+
+        timeout = aiohttp.ClientTimeout(total=30)
+        self.session = aiohttp.ClientSession(timeout=timeout)
+
+    def _build_request_headers(self) -> Dict[str, str]:
+        return {
+            'accept': 'application/json',
+            'content-type': 'application/x-www-form-urlencoded',
+            'cookie': self.cookie_string,
+            'idle_site_biz_code': 'COMMONPRO',
+            'idle_user_group_member_id': '',
+            'origin': 'https://seller.goofish.com',
+            'referer': ORDER_LIST_REFERER,
+            'user-agent': (
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                'AppleWebKit/537.36 (KHTML, like Gecko) '
+                'Chrome/138.0.0.0 Safari/537.36'
+            ),
+        }
+
+    def _build_request_params(self, data_val: str) -> Dict[str, str]:
+        token = self.cookies.get('_m_h5_tk', '').split('_')[0]
+        if not token:
+            raise ValueError(f'【{self.cookie_id_for_log}】Cookie 缺少 _m_h5_tk，无法请求历史订单列表')
+
+        params = {
+            'jsv': '2.7.2',
+            'appKey': '34839810',
+            't': str(int(time.time() * 1000)),
+            'sign': '',
+            'v': '1.0',
+            'type': 'json',
+            'accountSite': 'xianyu',
+            'dataType': 'json',
+            'timeout': '20000',
+            'api': ORDER_LIST_API_NAME,
+            'valueType': 'string',
+            'sessionOption': 'AutoLoginOnly',
+            'spm_cnt': 'a21107h.42831410.0.0',
+        }
+        params['sign'] = generate_sign(params['t'], token, data_val)
+        return params
+
+    async def _request_order_page(self, page_number: int, allow_retry: bool = True) -> Dict[str, Any]:
+        await self._ensure_session()
+        assert self.session is not None
+
+        payload = {
+            'pageNumber': page_number,
+            'rowsPerPage': DEFAULT_PAGE_SIZE,
+            'orderIds': '',
+            'queryCode': ORDER_LIST_QUERY_CODE,
+            'orderSearchParam': '{}',
+        }
+        data_val = json.dumps(payload, separators=(',', ':'))
+
+        try:
+            params = self._build_request_params(data_val)
+        except Exception as exc:
+            raise RuntimeError(str(exc)) from exc
+
+        async with self.session.post(
+            ORDER_LIST_API_URL,
+            params=params,
+            data={'data': data_val},
+            headers=self._build_request_headers(),
+        ) as response:
+            try:
+                res_json = await response.json(content_type=None)
+            except Exception as exc:
+                response_text = await response.text()
+                raise RuntimeError(
+                    f'【{self.cookie_id_for_log}】历史订单列表返回非 JSON: status={response.status}, body={response_text[:300]}'
+                ) from exc
+
+            cookies_updated = await self._apply_response_cookie_updates(response.headers)
+
+        ret_value = res_json.get('ret', [])
+        if any('SUCCESS::调用成功' in str(ret) for ret in ret_value):
+            return res_json
+
+        if allow_retry and cookies_updated and self._is_auth_failure_ret(ret_value):
+            logger.warning(f"【{self.cookie_id_for_log}】历史订单列表鉴权失败，Cookie 更新后重试第 {page_number} 页")
+            return await self._request_order_page(page_number, allow_retry=False)
+
+        raise classify_order_history_api_error(ret_value or res_json, self.cookie_id_for_log)
+
+    def _normalize_order_candidate(self, raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if not isinstance(raw, dict):
+            return None
+
+        common_data = raw.get('commonData') if isinstance(raw.get('commonData'), dict) else {}
+        buyer_info = raw.get('buyerInfoVO') if isinstance(raw.get('buyerInfoVO'), dict) else {}
+        price_info = raw.get('priceVO') if isinstance(raw.get('priceVO'), dict) else {}
+
+        order_id = str(common_data.get('orderId') or '').strip()
+        if not order_id:
+            return None
+
+        return {
+            'order_id': order_id,
+            'item_id': str(common_data.get('itemId') or '').strip() or None,
+            'sid': None,
+            'buyer_id': str(buyer_info.get('buyerId') or '').strip() or None,
+            'buyer_nick': str(buyer_info.get('userNick') or '').strip() or None,
+            'order_status': normalize_order_history_status(common_data.get('orderStatus')) or str(common_data.get('orderStatus') or '').strip() or None,
+            'amount': (
+                normalize_history_amount(price_info.get('totalPrice')) or
+                normalize_history_amount(price_info.get('confirmFee')) or
+                normalize_history_amount(price_info.get('auctionPrice'))
+            ),
+            'platform_created_at': parse_local_datetime_text_to_db_utc(common_data.get('createTime')),
+            'platform_paid_at': parse_local_datetime_text_to_db_utc(common_data.get('paySuccessTime')),
+            'platform_completed_at': parse_local_datetime_text_to_db_utc(common_data.get('finishTime')),
+            'raw_source': raw,
+        }
+
+    async def open(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        if self.session and not self.session.closed:
+            await self.session.close()
+        self.session = None
+        await self.fetcher.close()
+
+    async def fetch_recent_orders(
+        self,
+        max_orders: int = 100,
+        max_scroll_rounds: int = 12,
+        utc_start: Optional[str] = None,
+        utc_end_exclusive: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        del max_scroll_rounds
+
+        if max_orders <= 0:
+            return {
+                'orders': [],
+                'scanned_count': 0,
+                'matched_count': 0,
+                'out_of_range_count': 0,
+                'pages_scanned': 0,
+                'stopped_by_range': False,
+            }
+
+        await self.open()
+
+        captured_orders: List[Dict[str, Any]] = []
+        seen_order_ids = set()
+        page_number = 1
+        scanned_count = 0
+        out_of_range_count = 0
+        pages_scanned = 0
+        stopped_by_range = False
+
+        while len(captured_orders) < max_orders:
+            response_json = await self._request_order_page(page_number)
+            pages_scanned += 1
+            module = ((response_json.get('data') or {}).get('module') or {})
+            items = module.get('items') or []
+            next_page = str(module.get('nextPage') or '').lower() == 'true'
+            total_count = str(module.get('totalCount') or '').strip() or 'unknown'
+
+            if not isinstance(items, list):
+                items = []
+
+            page_scanned_count = 0
+            page_in_range_count = 0
+            page_before_count = 0
+            page_after_count = 0
+            page_unknown_count = 0
+
+            for raw_item in items:
+                candidate = self._normalize_order_candidate(raw_item)
+                if not candidate:
+                    continue
+
+                order_id = candidate.get('order_id')
+                if not order_id or order_id in seen_order_ids:
+                    continue
+
+                seen_order_ids.add(order_id)
+                scanned_count += 1
+                page_scanned_count += 1
+
+                anchor_time = resolve_order_history_anchor_time(candidate)
+                range_status = classify_order_history_range(anchor_time, utc_start=utc_start, utc_end_exclusive=utc_end_exclusive)
+                if range_status == 'in_range':
+                    captured_orders.append(candidate)
+                    page_in_range_count += 1
+                else:
+                    out_of_range_count += 1
+                    if range_status == 'before':
+                        page_before_count += 1
+                    elif range_status == 'after':
+                        page_after_count += 1
+                    else:
+                        page_unknown_count += 1
+
+                if len(captured_orders) >= max_orders:
+                    break
+
+            logger.info(
+                f"【{self.cookie_id_for_log}】历史订单列表第 {page_number} 页抓取完成: "
+                f"page_items={len(items)}, scanned={page_scanned_count}, in_range={page_in_range_count}, "
+                f"before_range={page_before_count}, after_range={page_after_count}, unknown_anchor={page_unknown_count}, "
+                f"captured={len(captured_orders)}, totalCount={total_count}, nextPage={next_page}"
+            )
+
+            if len(captured_orders) >= max_orders or not next_page or not items:
+                break
+
+            if (
+                utc_start and utc_end_exclusive
+                and page_scanned_count > 0
+                and page_in_range_count == 0
+                and page_unknown_count == 0
+                and page_before_count == page_scanned_count
+            ):
+                stopped_by_range = True
+                logger.info(
+                    f"【{self.cookie_id_for_log}】历史订单列表在第 {page_number} 页已全部早于开始时间，停止继续翻页"
+                )
+                break
+
+            page_number += 1
+
+        matched_orders = captured_orders[:max_orders]
+        return {
+            'orders': matched_orders,
+            'scanned_count': scanned_count,
+            'matched_count': len(matched_orders),
+            'out_of_range_count': out_of_range_count,
+            'pages_scanned': pages_scanned,
+            'stopped_by_range': stopped_by_range,
+        }
+
+    async def fetch_order_detail(self, order_id: str, force_refresh: bool = True) -> Optional[Dict[str, Any]]:
+        return await self.fetcher.fetch_order_detail(order_id)

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,0 +1,118 @@
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+
+DB_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+LOCAL_DATE_FORMAT = "%Y-%m-%d"
+UTC = timezone.utc
+LOCAL_TIMEZONE = ZoneInfo("Asia/Shanghai")
+
+
+def get_local_now() -> datetime:
+    """返回当前北京时间。"""
+    return datetime.now(LOCAL_TIMEZONE)
+
+
+def parse_db_timestamp(value: str) -> Optional[datetime]:
+    """将数据库时间字符串按 UTC 解析为 datetime。"""
+    text = str(value or "").strip()
+    if not text:
+        return None
+
+    normalized = text.replace("Z", "+00:00") if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        try:
+            parsed = datetime.strptime(text, DB_DATETIME_FORMAT)
+        except ValueError:
+            return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def to_db_utc_string(value: datetime) -> str:
+    """将 datetime 转成数据库使用的 UTC 时间字符串。"""
+    if value.tzinfo is None:
+        aware_value = value.replace(tzinfo=LOCAL_TIMEZONE)
+    else:
+        aware_value = value
+    return aware_value.astimezone(UTC).strftime(DB_DATETIME_FORMAT)
+
+
+def parse_local_datetime_text_to_db_utc(value: str) -> Optional[str]:
+    """将中文/本地时间文本解析为数据库使用的 UTC 时间字符串。"""
+    text = str(value or "").strip()
+    if not text:
+        return None
+
+    normalized = re.sub(r"\s+", " ", text.replace("\u3000", " ")).strip()
+    match = re.search(
+        r"(?P<year>\d{4})\s*(?:年|[-/.])\s*(?P<month>\d{1,2})\s*(?:月|[-/.])\s*(?P<day>\d{1,2})"
+        r"\s*(?:日)?\s*(?:T|\s+)\s*(?P<hour>\d{1,2})\s*:\s*(?P<minute>\d{1,2})"
+        r"(?:\s*:\s*(?P<second>\d{1,2}))?",
+        normalized,
+    )
+    if not match:
+        return None
+
+    try:
+        local_datetime = datetime(
+            int(match.group("year")),
+            int(match.group("month")),
+            int(match.group("day")),
+            int(match.group("hour")),
+            int(match.group("minute")),
+            int(match.group("second") or 0),
+            tzinfo=LOCAL_TIMEZONE,
+        )
+    except ValueError:
+        return None
+
+    return to_db_utc_string(local_datetime)
+
+
+def local_date_to_utc_start(date_str: str) -> Optional[str]:
+    """将北京时间日期转成 UTC 起始时间字符串。"""
+    text = str(date_str or "").strip()
+    if not text:
+        return None
+
+    try:
+        local_start = datetime.strptime(text, LOCAL_DATE_FORMAT).replace(tzinfo=LOCAL_TIMEZONE)
+    except ValueError:
+        return None
+    return to_db_utc_string(local_start)
+
+
+def local_date_to_utc_end_exclusive(date_str: str) -> Optional[str]:
+    """将北京时间日期转成次日零点的 UTC 时间字符串。"""
+    text = str(date_str or "").strip()
+    if not text:
+        return None
+
+    try:
+        local_start = datetime.strptime(text, LOCAL_DATE_FORMAT).replace(tzinfo=LOCAL_TIMEZONE)
+    except ValueError:
+        return None
+    return to_db_utc_string(local_start + timedelta(days=1))
+
+
+def utc_timestamp_to_local_date_string(value: str) -> Optional[str]:
+    """将 UTC 时间字符串转换为北京时间日期字符串。"""
+    parsed = parse_db_timestamp(value)
+    if not parsed:
+        return None
+    return parsed.astimezone(LOCAL_TIMEZONE).strftime(LOCAL_DATE_FORMAT)
+
+
+def utc_timestamp_to_local_datetime(value: str) -> Optional[datetime]:
+    """将 UTC 时间字符串转换为北京时间 datetime。"""
+    parsed = parse_db_timestamp(value)
+    if not parsed:
+        return None
+    return parsed.astimezone(LOCAL_TIMEZONE)


### PR DESCRIPTION
## 新增功能

- 支持按日期范围同步历史订单及订单详情。
- 支持从 IM 会话发现个人卖家订单。
- 支持手动仅更新为已发货状态。
- 支持选择卡密内容进行完整补发。
- 支持账号级自动评价开关及评价模板，默认关闭。
- 支持定时评价已完成订单，也可手动立即执行。
- 增加历史同步进度和自动评价执行记录。