### PR TITLE
fix: 多规格商品自动发货规格获取错误

### DIFF
--- a/XianyuAutoAsync.py
+++ b/XianyuAutoAsync.py
@@ -1470,6 +1470,15 @@ class XianyuLive:
                 except Exception as parse_e:
                     logger.warning(f"解析dynamicOperation JSON失败: {parse_e}")
 
+            # 方法2.5: 从 message['3'] 中直接提取 orderId
+            if not order_id:
+                message_3 = message.get('3')
+                if isinstance(message_3, dict):
+                    direct_order_id = message_3.get('orderId')
+                    if direct_order_id and str(direct_order_id).isdigit():
+                        order_id = str(direct_order_id)
+                        logger.info(f'【{self.cookie_id}】✅ 从message[3].orderId提取到订单ID: {order_id}')
+
             # 方法3: 如果前面的方法都失败，尝试在整个消息中搜索订单ID模式
             if not order_id:
                 try:
@@ -1478,10 +1487,10 @@ class XianyuLive:
 
                     # 搜索各种可能的订单ID模式
                     patterns = [
-                        r'orderId[=:](\d{10,})',  # orderId=123456789 或 orderId:123456789
+                        r'orderId["\']?\s*[:=]\s*["\']?(\d{10,})',  # orderId: '123' 或 orderId=123
                         r'order_detail\?id=(\d{10,})',  # order_detail?id=123456789
                         r'"id"\s*:\s*"?(\d{10,})"?',  # "id":"123456789" 或 "id":123456789
-                        r'bizOrderId[=:](\d{10,})',  # bizOrderId=123456789
+                        r'bizOrderId["\']?\s*[:=]\s*["\']?(\d{10,})',  # bizOrderId=123456789
                     ]
 
                     for pattern in patterns:

--- a/utils/seller_order_sync.py
+++ b/utils/seller_order_sync.py
@@ -84,33 +84,54 @@ async def fetch_order_detail_direct(
         except SellerApiError as exc:
             logger.debug(f"【{cookie_id}】订单 {order_id} 列表查询失败: {exc}")
 
-        # 规格信息只能从发货页渲染接口拿
+        # 规格信息优先从买家端订单详情接口拿（skuInfo 格式固定为 "规格名:规格值"）
         try:
-            render = parse_consign_render(await api.get_consign_render(order_id))
-            for key in (
-                "spec_name",
-                "spec_value",
-                "need_serial_number",
-                "need_upload_report",
-                "support_consign_type",
-            ):
-                if render.get(key) not in (None, "", []):
-                    result[key] = render[key]
-            # 列表接口缺字段时用渲染接口补齐
-            for key in (
-                "item_id",
-                "item_title",
-                "receiver_name",
-                "receiver_phone",
-                "receiver_address",
-                "auction_price",
-            ):
-                if not result.get(key) and render.get(key):
-                    result[key] = render[key]
-            if not result.get("buy_num"):
-                result["buy_num"] = render.get("buy_num") or 1
-        except SellerApiError as exc:
-            logger.debug(f"【{cookie_id}】订单 {order_id} 发货页渲染失败: {exc}")
+            detail = await api.get_order_detail(order_id)
+            components = detail.get("components") or []
+            for comp in components:
+                if comp.get("render") == "orderInfoVO":
+                    item_info = (comp.get("data") or {}).get("itemInfo") or {}
+                    sku_info = item_info.get("skuInfo", "")
+                    if sku_info and ":" in sku_info:
+                        parts = sku_info.split(":", 1)
+                        result["spec_name"] = parts[0].strip()
+                        result["spec_value"] = parts[1].strip() if len(parts) > 1 else ""
+                        logger.debug(
+                            f"【{cookie_id}】订单 {order_id} 从 order.detail 获取规格: "
+                            f"{result['spec_name']}={result['spec_value']}"
+                        )
+                    break
+        except (SellerApiError, Exception) as exc:
+            logger.debug(f"【{cookie_id}】订单 {order_id} order.detail 查询失败: {exc}")
+
+        # 规格信息的备用来源：发货页渲染接口的 itemInfoLines
+        if not result.get("spec_value"):
+            try:
+                render = parse_consign_render(await api.get_consign_render(order_id))
+                for key in (
+                    "spec_name",
+                    "spec_value",
+                    "need_serial_number",
+                    "need_upload_report",
+                    "support_consign_type",
+                ):
+                    if render.get(key) not in (None, "", []):
+                        result[key] = render[key]
+                # 列表接口缺字段时用渲染接口补齐
+                for key in (
+                    "item_id",
+                    "item_title",
+                    "receiver_name",
+                    "receiver_phone",
+                    "receiver_address",
+                    "auction_price",
+                ):
+                    if not result.get(key) and render.get(key):
+                        result[key] = render[key]
+                if not result.get("buy_num"):
+                    result["buy_num"] = render.get("buy_num") or 1
+            except SellerApiError as exc:
+                logger.debug(f"【{cookie_id}】订单 {order_id} 发货页渲染失败: {exc}")
     except Exception as e:
         logger.warning(f"【{cookie_id}】订单 {order_id} 直连获取异常: {e}")
     finally:

--- a/utils/xianyu_seller_api.py
+++ b/utils/xianyu_seller_api.py
@@ -451,6 +451,87 @@ class XianyuSellerAPI:
         )
         return (result.get("data") or {}) or {}
 
+    async def get_order_detail(self, order_id: str) -> Dict[str, Any]:
+        """通过买家端订单详情接口获取订单信息（含 skuInfo 规格字段）。
+
+        ``mtop.idle.web.trade.order.detail`` 返回的 ``skuInfo`` 字段格式固定为
+        ``"规格名:规格值"``（如 ``"尺码:天卡"``），比 ``consign.page.render`` 的
+        ``itemInfoLines`` 更可靠，不受字段排序影响。
+
+        注意：这是买家端接口，origin 必须指向 www.goofish.com。
+        """
+        guard = risk_control.registry.get(self.cookie_id)
+        if guard.is_blocked:
+            raise risk_control.RiskControlBlocked(
+                self.cookie_id, guard.remaining_seconds, guard.last_hit_reason
+            )
+
+        if not self.cookies_str:
+            raise SellerApiError("mtop.idle.web.trade.order.detail", ["Cookie 为空"])
+
+        last_ret: List[str] = []
+        data_val = json.dumps({"tid": str(order_id)}, separators=(",", ":"))
+        timestamp = str(int(time.time() * 1000))
+
+        headers = {
+            "accept": "application/json",
+            "accept-language": "zh-CN,zh;q=0.9,en;q=0.8",
+            "content-type": "application/x-www-form-urlencoded",
+            "origin": "https://www.goofish.com",
+            "referer": "https://www.goofish.com/",
+            "user-agent": self.USER_AGENT,
+            "cookie": self.cookies_str.replace("\n", "").replace("\r", ""),
+        }
+
+        for attempt in range(2):
+            params = {
+                "jsv": "2.7.2",
+                "appKey": self.APP_KEY,
+                "t": timestamp,
+                "sign": generate_sign(timestamp, self._token(), data_val),
+                "v": "1.0",
+                "type": "originaljson",
+                "accountSite": "xianyu",
+                "dataType": "json",
+                "timeout": "20000",
+                "api": "mtop.idle.web.trade.order.detail",
+                "sessionOption": "AutoLoginOnly",
+                "spm_cnt": "a21ybx.order-detail.0.0",
+            }
+
+            session = await self._ensure_session()
+            url = self.BASE_URL.format(api="mtop.idle.web.trade.order.detail", version="1.0")
+            await guard.acquire()
+            async with session.post(
+                url,
+                params=params,
+                data={"data": data_val},
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=20),
+            ) as response:
+                result = await response.json(content_type=None)
+                self._merge_response_cookies(response)
+
+            ret_list = [str(v) for v in (result.get("ret", []) if isinstance(result, dict) else [])]
+            if any("SUCCESS" in v for v in ret_list):
+                guard.reset()
+                return (result.get("data") or {}) or {}
+
+            last_ret = ret_list
+            if risk_control.is_risk_control_error("; ".join(ret_list)):
+                guard.trip("; ".join(ret_list))
+                raise SellerApiError("mtop.idle.web.trade.order.detail", ret_list)
+
+            token_expired = any(
+                "TOKEN_EXPIRED" in v or "TOKEN_EXOIRED" in v or "FAIL_SYS_TOKEN_EMPTY" in v
+                for v in ret_list
+            )
+            if not token_expired or attempt == 1:
+                break
+            logger.debug(f"【{self.cookie_id}】order.detail 令牌过期，使用新令牌重试")
+
+        raise SellerApiError("mtop.idle.web.trade.order.detail", last_ret)
+
     # ------------------------------------------------------------------
     # 退款
     # ------------------------------------------------------------------
@@ -733,7 +814,6 @@ def parse_consign_render(data: Dict[str, Any]) -> Dict[str, Any]:
     spec_value = ""
     for line in item_vo.get("itemInfoLines") or []:
         key = _text(line.get("key"))
-        # 商品 ID 也放在 itemInfoLines 里，只取规格那一行
         if key and key != "商品ID":
             spec_name = key
             spec_value = _text(line.get("value"))


### PR DESCRIPTION
## 问题

多规格商品自动发货时规格获取错误，取到'商品分类'而非真正的规格（如'天卡'）。

## 根因

1. itemInfoLines 字段顺序不确定，原代码取第一个非'商品ID'行
2. _extract_order_id 未处理 message['3']['orderId'] 格式

## 修复

1. 新增 get_order_detail 方法，优先用 skuInfo 获取规格
2. 修改 etch_order_detail_direct 优先用 order.detail 接口
3. 修复 _extract_order_id 支持新消息格式

## 测试

已部署验证：订单规格正确获取为'尺码:天卡'