### PR TITLE
feat: 增加浅色、深色与跟随系统主题

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -2,6 +2,7 @@ import React, { Suspense, lazy, useState, useEffect } from 'react';
 import Sidebar from './components/Sidebar';
 import GlobalFeedback from './components/GlobalFeedback';
 import AnnouncementBanner from './components/AnnouncementBanner';
+import ThemeToggle from './components/ThemeToggle';
 import { login, verifyToken, getPublicSettings, register, sendVerificationCode } from './services/api';
 import { ShieldCheck, ArrowRight, Loader2, User, Lock, Menu, Mail, KeyRound, CheckCircle2 } from 'lucide-react';
 
@@ -199,9 +200,9 @@ const App: React.FC = () => {
 
   if (checkingAuth) {
       return (
-          <div className="min-h-screen flex items-center justify-center bg-[#fffdf5]">
-              <div className="flex items-center gap-3 text-sm font-semibold text-gray-600">
-                <Loader2 className="h-5 w-5 animate-spin text-[#b29c00]" />
+          <div className="min-h-screen flex items-center justify-center bg-[var(--app-bg)]">
+              <div className="flex items-center gap-3 text-sm font-semibold text-[var(--text-muted)]">
+                <Loader2 className="h-5 w-5 animate-spin text-[var(--brand-text)]" />
                 正在验证登录状态
               </div>
           </div>
@@ -211,13 +212,14 @@ const App: React.FC = () => {
   // Login Screen Component
   if (!isLoggedIn) {
     return (
-      <div className="min-h-screen bg-[#fffdf5] p-4 font-sans sm:p-6">
+      <div className="relative min-h-screen bg-[var(--app-bg)] p-4 font-sans text-[var(--text)] sm:p-6">
+        <ThemeToggle compact className="absolute right-4 top-4 z-10 sm:right-6 sm:top-6" />
         <div className="mx-auto flex min-h-[calc(100vh-2rem)] max-w-5xl items-center justify-center sm:min-h-[calc(100vh-3rem)]">
-          <div className="grid w-full overflow-hidden rounded-3xl bg-white lg:grid-cols-[1.05fr_0.95fr]"
+          <div className="grid w-full overflow-hidden rounded-3xl bg-[var(--surface)] lg:grid-cols-[1.05fr_0.95fr]"
                style={{ border: '1px solid var(--border)', boxShadow: 'var(--shadow-lg)' }}>
             {/* 品牌侧：黄色渐变作为整站第一印象 */}
             <div
-              className="hidden min-h-[560px] flex-col justify-between p-10 lg:flex"
+              className="theme-brand-panel hidden min-h-[560px] flex-col justify-between p-10 lg:flex"
               style={{ background: 'linear-gradient(155deg, #fff8d1 0%, #ffe566 55%, #ffe100 100%)' }}
             >
               <div>
@@ -425,7 +427,7 @@ const App: React.FC = () => {
                         <button
                           type="button"
                           onClick={() => { setAuthMode('register'); setLoginError(''); setLoginNotice(''); }}
-                          className="ml-1 font-bold text-[#8c7900] hover:underline"
+                          className="ml-1 font-bold text-[var(--brand-text)] hover:underline"
                         >
                           注册新账号
                         </button>
@@ -435,7 +437,7 @@ const App: React.FC = () => {
                         <button
                           type="button"
                           onClick={() => { setAuthMode('login'); setRegError(''); setRegNotice(''); }}
-                          className="ml-1 font-bold text-[#8c7900] hover:underline"
+                          className="ml-1 font-bold text-[var(--brand-text)] hover:underline"
                         >
                           返回登录
                         </button>
@@ -456,7 +458,7 @@ const App: React.FC = () => {
   }
 
   return (
-    <div className="flex min-h-screen bg-[#fffdf5] text-[#2a2416]">
+    <div className="flex min-h-screen bg-[var(--app-bg)] text-[var(--text)]">
       <GlobalFeedback />
       <Sidebar 
         activeTab={activeTab} 
@@ -474,7 +476,7 @@ const App: React.FC = () => {
       />
       
       <main className="min-h-screen min-w-0 flex-1 overflow-y-auto lg:ml-[248px]">
-        <header className="sticky top-0 z-20 flex h-14 items-center gap-3 border-b border-[#f0e6c8] bg-white px-4 lg:hidden">
+        <header className="sticky top-0 z-20 flex h-14 items-center gap-3 border-b border-[var(--border)] bg-[var(--surface)] px-4 lg:hidden">
           <button
             type="button"
             onClick={() => setMobileMenuOpen(true)}
@@ -488,6 +490,7 @@ const App: React.FC = () => {
             <p className="truncate text-sm font-bold">{pageLabels[activeTab] || '闲鱼超级管家'}</p>
             <p className="text-[11px] text-gray-400">闲鱼超级管家</p>
           </div>
+          <ThemeToggle compact className="ml-auto" />
         </header>
         {activeTab !== 'messages' && <AnnouncementBanner />}
         <div className={

--- a/frontend/components/AIReply.tsx
+++ b/frontend/components/AIReply.tsx
@@ -220,7 +220,7 @@ const AIReply: React.FC = () => {
                         href={FREE_TOKEN_HOME}
                         target="_blank"
                         rel="noreferrer noopener"
-                        className="inline-flex items-center gap-1 rounded-md bg-brand-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-brand-600"
+                        className="inline-flex items-center gap-1 rounded-md bg-brand-500 px-3 py-1.5 text-xs font-semibold text-brand-ink hover:bg-brand-600"
                       >
                         免费领取 token
                         <ExternalLink className="h-3.5 w-3.5" />

--- a/frontend/components/AccountList.tsx
+++ b/frontend/components/AccountList.tsx
@@ -644,7 +644,7 @@ const AccountList: React.FC = () => {
                     <span className="flex items-center gap-1.5">
                       <Users className="h-4 w-4 text-gray-400" />
                       {account.followers?.toLocaleString() ?? '--'} 粉丝
-                      <span className="text-gray-300">/</span>
+                      <span className="text-gray-400">/</span>
                       {account.following?.toLocaleString() ?? '--'} 关注
                     </span>
                   )}
@@ -786,7 +786,7 @@ const AccountList: React.FC = () => {
 
                   <div className="modal-body py-5">
                       <div className="text-center">
-                          <div className="relative mx-auto flex h-60 w-60 items-center justify-center overflow-hidden rounded-md border border-gray-200 bg-gray-50">
+                          <div className="media-light-surface relative mx-auto flex h-60 w-60 items-center justify-center overflow-hidden rounded-md border border-gray-200 bg-gray-50">
                               {qrStatus === 'loading' && <Loader2 className="h-9 w-9 animate-spin text-amber-500" />}
                               {(qrStatus === 'waiting' || qrStatus === 'scanned') && (
                                   <img src={qrCodeUrl} alt="闲鱼登录二维码" className="h-full w-full p-2" />

--- a/frontend/components/Dashboard.tsx
+++ b/frontend/components/Dashboard.tsx
@@ -36,7 +36,7 @@ const StatCard: React.FC<{ title: string; value: string | number; icon: React.El
   <div className="metric-card">
     <div className="flex items-start justify-between gap-3">
       <span className={`flex h-9 w-9 items-center justify-center rounded-md ${colorClass}`}>
-        <Icon className="h-4 w-4 text-white" />
+        <Icon className="h-4 w-4 text-[var(--brand-ink)]" />
       </span>
       {trend && <span className="status-badge status-badge-success flex items-center gap-1">
         <TrendingUp className="w-3 h-3" /> {trend}
@@ -539,32 +539,32 @@ const Dashboard: React.FC = () => {
                 barGap={6}
                 barCategoryGap="28%"
               >
-                <CartesianGrid vertical={false} stroke="#ebe9e3" strokeDasharray="4 4" />
+                <CartesianGrid vertical={false} stroke="var(--chart-grid)" strokeDasharray="4 4" />
                 <XAxis
                   dataKey="name"
                   axisLine={false}
                   tickLine={false}
-                  tick={{fill: '#66625c', fontSize: 12, fontWeight: 600}}
+                  tick={{fill: 'var(--text-muted)', fontSize: 12, fontWeight: 600}}
                   dy={10}
                   interval="preserveStartEnd"
                 />
                 <YAxis
                   axisLine={false}
                   tickLine={false}
-                  tick={{fill: '#b0aaa0', fontSize: 12, fontWeight: 500}}
+                  tick={{fill: 'var(--text-soft)', fontSize: 12, fontWeight: 500}}
                   tickFormatter={(value) => `¥${value}`}
                 />
                 <Tooltip
                   contentStyle={{
-                    backgroundColor: '#ffffff',
+                    backgroundColor: 'var(--surface)',
                     borderRadius: '14px',
-                    border: '1px solid #ebe9e3',
-                    boxShadow: '0 8px 24px rgba(122, 96, 20, 0.12)',
+                    border: '1px solid var(--border)',
+                    boxShadow: 'var(--shadow-md)',
                     padding: '10px 14px'
                   }}
-                  itemStyle={{ color: '#2a2416', fontWeight: 600 }}
-                  labelStyle={{ color: '#66625c', fontWeight: 600, marginBottom: 4 }}
-                  cursor={{ fill: 'rgba(255, 225, 0, 0.12)', radius: 8 }}
+                  itemStyle={{ color: 'var(--text)', fontWeight: 600 }}
+                  labelStyle={{ color: 'var(--text-muted)', fontWeight: 600, marginBottom: 4 }}
+                  cursor={{ fill: 'var(--chart-cursor)', radius: 8 }}
                   formatter={(value, name) => {
                     const label = name === 'confirmed' ? '已到账' : '成交额';
                     return [`¥${Number(value).toFixed(2)}`, label];
@@ -576,7 +576,7 @@ const Dashboard: React.FC = () => {
                   iconType="circle"
                   iconSize={8}
                   formatter={(value) => (
-                    <span style={{ color: '#66625c', fontSize: 12 }}>
+                    <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>
                       {value === 'confirmed' ? '已到账' : '成交额'}
                     </span>
                   )}
@@ -602,30 +602,32 @@ const Dashboard: React.FC = () => {
             ) : (
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={productSalesData} layout="vertical" barCategoryGap="30%">
-                  <CartesianGrid strokeDasharray="4 4" horizontal={true} vertical={false} stroke="#ebe9e3" />
+                  <CartesianGrid strokeDasharray="4 4" horizontal={true} vertical={false} stroke="var(--chart-grid)" />
                   <XAxis
                     type="number"
                     axisLine={false}
                     tickLine={false}
-                    tick={{ fill: '#b0aaa0', fontSize: 12 }}
+                    tick={{ fill: 'var(--text-soft)', fontSize: 12 }}
                   />
                   <YAxis
                     type="category"
                     dataKey="name"
                     axisLine={false}
                     tickLine={false}
-                    tick={{ fill: '#66625c', fontSize: 12 }}
+                    tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
                     width={100}
                   />
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: '#fff',
-                      border: '1px solid #ebe9e3',
+                      backgroundColor: 'var(--surface)',
+                      border: '1px solid var(--border)',
                       borderRadius: '14px',
-                      boxShadow: '0 8px 24px rgba(122, 96, 20, 0.12)',
+                      boxShadow: 'var(--shadow-md)',
                       padding: '10px 14px'
                     }}
-                    cursor={{ fill: 'rgba(255, 225, 0, 0.12)', radius: 8 }}
+                    itemStyle={{ color: 'var(--text)', fontWeight: 600 }}
+                    labelStyle={{ color: 'var(--text-muted)', fontWeight: 600 }}
+                    cursor={{ fill: 'var(--chart-cursor)', radius: 8 }}
                   />
                   {/* 同上：商品只有一两个时不限宽会变成超粗横条 */}
                   <Bar dataKey="sales" fill="#ffd426" radius={[0, 8, 8, 0]} maxBarSize={28} />
@@ -666,25 +668,26 @@ const Dashboard: React.FC = () => {
                     activeShape={{ outerRadius: 98 }}
                   >
                     {sourceDataData.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill={entry.color} stroke="#ffffff" strokeWidth={2} />
+                      <Cell key={`cell-${index}`} fill={entry.color} stroke="var(--surface)" strokeWidth={2} />
                     ))}
                   </Pie>
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: '#ffffff',
-                      border: '1px solid #e9e7e2',
+                      backgroundColor: 'var(--surface)',
+                      border: '1px solid var(--border)',
                       borderRadius: '14px',
-                      boxShadow: '0 8px 24px rgba(35, 33, 30, 0.10)',
+                      boxShadow: 'var(--shadow-md)',
                       padding: '10px 14px'
                     }}
-                    itemStyle={{ color: '#23211e', fontWeight: 600 }}
+                    itemStyle={{ color: 'var(--text)', fontWeight: 600 }}
+                    labelStyle={{ color: 'var(--text-muted)', fontWeight: 600 }}
                     formatter={(value, name) => [`${value} 单`, name]}
                   />
                   <Legend
                     verticalAlign="bottom"
                     height={36}
                     iconType="circle"
-                    formatter={(value) => <span style={{ color: '#6b6862', fontWeight: 500 }}>{value}</span>}
+                    formatter={(value) => <span style={{ color: 'var(--text-muted)', fontWeight: 500 }}>{value}</span>}
                   />
                 </PieChart>
               </ResponsiveContainer>
@@ -746,7 +749,7 @@ const Dashboard: React.FC = () => {
                         <td>
                           <div className="flex items-center gap-3">
                             <div className="h-11 w-11 flex-shrink-0 overflow-hidden rounded-md border border-gray-100 bg-gray-100">
-                              <PackageCheck className="w-full h-full text-gray-300 p-2" />
+                              <PackageCheck className="w-full h-full text-gray-400 p-2" />
                             </div>
                             <div className="min-w-0">
                               <div className="font-bold text-gray-900 text-sm line-clamp-1">
@@ -810,18 +813,19 @@ const Dashboard: React.FC = () => {
                       activeShape={{ outerRadius: 108 }}
                     >
                       {categoryDataData.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.color || COLORS[index % COLORS.length]} stroke="#ffffff" strokeWidth={2} />
+                        <Cell key={`cell-${index}`} fill={entry.color || COLORS[index % COLORS.length]} stroke="var(--surface)" strokeWidth={2} />
                       ))}
                     </Pie>
                     <Tooltip
                       contentStyle={{
-                        backgroundColor: '#fff',
-                        border: '1px solid #e9e7e2',
+                        backgroundColor: 'var(--surface)',
+                        border: '1px solid var(--border)',
                         borderRadius: '14px',
-                        boxShadow: '0 8px 24px rgba(35, 33, 30, 0.10)',
+                        boxShadow: 'var(--shadow-md)',
                         padding: '10px 14px'
                       }}
-                      itemStyle={{ color: '#23211e', fontWeight: 600 }}
+                      itemStyle={{ color: 'var(--text)', fontWeight: 600 }}
+                      labelStyle={{ color: 'var(--text-muted)', fontWeight: 600 }}
                       formatter={(value: number) => `¥${value.toLocaleString()}`}
                     />
                   </PieChart>

--- a/frontend/components/ItemList.tsx
+++ b/frontend/components/ItemList.tsx
@@ -133,7 +133,7 @@ const ItemImage: React.FC<{ item: Item }> = ({ item }) => {
 
   if (!src || failed) {
     return (
-      <div className="flex h-full w-full items-center justify-center text-gray-300">
+      <div className="flex h-full w-full items-center justify-center text-gray-400">
         <Box className="h-8 w-8" />
       </div>
     );

--- a/frontend/components/MessageManagement.tsx
+++ b/frontend/components/MessageManagement.tsx
@@ -384,14 +384,14 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
   };
 
   const renderMessages = () => (
-    <div className="grid h-full min-h-0 overflow-hidden bg-white lg:grid-cols-[356px_minmax(0,1fr)]">
-      <aside className={`${mobilePane === 'chat' ? 'hidden lg:flex' : 'flex'} min-h-0 flex-col border-b border-[#f0e6c8] lg:border-b-0 lg:border-r`}>
-        <div className="flex h-[68px] shrink-0 items-center gap-3 border-b border-[#f0e6c8] px-4">
+    <div className="grid h-full min-h-0 overflow-hidden bg-[var(--surface)] lg:grid-cols-[356px_minmax(0,1fr)]">
+      <aside className={`${mobilePane === 'chat' ? 'hidden lg:flex' : 'flex'} min-h-0 flex-col border-b border-[var(--border)] lg:border-b-0 lg:border-r`}>
+        <div className="flex h-[68px] shrink-0 items-center gap-3 border-b border-[var(--border)] px-4">
           <select
             value={activeAccountId}
             onChange={(event) => setActiveAccountId(event.target.value)}
             aria-label="消息账号"
-            className="h-10 min-w-0 flex-1 rounded-md border border-[#e6d69a] bg-white px-3 text-sm font-bold outline-none focus:border-[#e6c600]"
+            className="h-10 min-w-0 flex-1 rounded-md border border-[var(--border-strong)] bg-[var(--surface)] px-3 text-sm font-bold text-[var(--text)] outline-none focus:border-[var(--brand)]"
           >
             {accounts.length === 0 && <option value="">暂无账号</option>}
             {accounts.map((account) => (
@@ -404,7 +404,7 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
             type="button"
             onClick={() => void Promise.all([loadAccounts(), loadConversations()])}
             title="刷新账号和会话"
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full hover:bg-[#fff9e8]"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full hover:bg-[var(--surface-hover)]"
           >
             <RefreshCw className={`h-4 w-4 ${
               accountsLoading || conversationsLoading ? 'animate-spin' : ''
@@ -414,20 +414,20 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
             type="button"
             onClick={() => setView('filters')}
             title="消息过滤规则"
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full hover:bg-[#fff9e8]"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full hover:bg-[var(--surface-hover)]"
           >
             <Settings2 className="h-4 w-4" />
           </button>
         </div>
 
-        <div className="border-b border-[#f0e6c8] p-3">
+        <div className="border-b border-[var(--border)] p-3">
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#aaa]" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-soft)]" />
             <input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="搜索联系人、商品或消息"
-              className="h-9 w-full rounded-md bg-[#fff9e8] pl-9 pr-3 text-sm outline-none focus:ring-2 focus:ring-[#ffe100]"
+              className="h-9 w-full rounded-md bg-[var(--surface-subtle)] pl-9 pr-3 text-sm text-[var(--text)] outline-none placeholder:text-[var(--text-soft)] focus:ring-2 focus:ring-[var(--brand)]"
             />
           </div>
         </div>
@@ -450,27 +450,27 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
                   setMobilePane('chat');
                 }}
                 className={`grid w-full grid-cols-[48px_minmax(0,1fr)_auto] gap-3 px-4 py-3 text-left ${
-                  selected ? 'bg-[#f5edd6]' : 'hover:bg-[#fffdf5]'
+                  selected ? 'bg-[var(--surface-strong)]' : 'hover:bg-[var(--surface-hover)]'
                 }`}
               >
                 {renderAvatar(conversation.otherUserAvatar, title, 'h-12 w-12 rounded-full')}
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
-                    <p className="truncate text-sm font-bold text-[#2a2416]">{title}</p>
+                    <p className="truncate text-sm font-bold text-[var(--text)]">{title}</p>
                     {conversation.unreadCount > 0 && (
-                      <span className="min-w-5 rounded-full bg-[#ff4d4f] px-1.5 text-center text-[10px] leading-5 text-white">
+                      <span className="min-w-5 rounded-full bg-[var(--unread-badge)] px-1.5 text-center text-[10px] leading-5 text-white">
                         {conversation.unreadCount > 99 ? '99+' : conversation.unreadCount}
                       </span>
                     )}
                   </div>
-                  <p className="mt-1 truncate text-xs text-[#777]">
+                  <p className="mt-1 truncate text-xs text-[var(--text-muted)]">
                     {conversation.lastMessageSummary || '暂无消息'}
                   </p>
-                  <p className="mt-1 truncate text-[10px] text-[#aaa]">
+                  <p className="mt-1 truncate text-[10px] text-[var(--text-soft)]">
                     {conversation.itemTitle || (conversation.itemId ? `商品 ${conversation.itemId}` : '普通会话')}
                   </p>
                 </div>
-                <span className="pt-0.5 text-[10px] text-[#aaa]">
+                <span className="pt-0.5 text-[10px] text-[var(--text-soft)]">
                   {formatTimestamp(conversation.lastMessageTime)}
                 </span>
               </button>
@@ -478,8 +478,8 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
           })}
           {!conversationsLoading && visibleConversations.length === 0 && (
             <div className="px-6 py-20 text-center">
-              <Inbox className="mx-auto h-9 w-9 text-[#d0d0d0]" />
-              <p className="mt-3 text-sm text-[#777]">
+              <Inbox className="mx-auto h-9 w-9 text-[var(--text-soft)]" />
+              <p className="mt-3 text-sm text-[var(--text-muted)]">
                 {activeAccount?.connected ? '暂无会话' : '账号离线，无法读取会话'}
               </p>
             </div>
@@ -490,22 +490,22 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
       <section className={`${mobilePane === 'list' ? 'hidden lg:flex' : 'flex'} min-h-0 min-w-0 flex-col`}>
         {activeConversation ? (
           <>
-            <header className="flex h-[68px] shrink-0 items-center justify-between border-b border-[#f0e6c8] px-5">
+            <header className="flex h-[68px] shrink-0 items-center justify-between border-b border-[var(--border)] px-5">
               <div className="flex min-w-0 items-center gap-2">
                 <button
                   type="button"
                   onClick={() => setMobilePane('list')}
-                  className="-ml-2 flex h-9 w-9 shrink-0 items-center justify-center rounded-md hover:bg-[#fff9e8] lg:hidden"
+                  className="-ml-2 flex h-9 w-9 shrink-0 items-center justify-center rounded-md hover:bg-[var(--surface-hover)] lg:hidden"
                   title="返回会话列表"
                   aria-label="返回会话列表"
                 >
                   <ArrowLeft className="h-5 w-5" />
                 </button>
                 <div className="min-w-0">
-                  <h3 className="truncate text-base font-bold text-[#2a2416]">
+                  <h3 className="truncate text-base font-bold text-[var(--text)]">
                     {activeConversation.otherUserName || `闲鱼用户 ${activeConversation.otherUserId}`}
                   </h3>
-                  <p className="mt-0.5 truncate text-xs text-[#999]">
+                  <p className="mt-0.5 truncate text-xs text-[var(--text-soft)]">
                     {activeConversation.otherUserId}
                   </p>
                 </div>
@@ -520,7 +520,7 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
               </span>
             </header>
 
-            <div className="flex min-h-[84px] shrink-0 items-center gap-3 border-b border-[#f0e6c8] px-4 py-3 sm:min-h-[92px] sm:gap-4 sm:px-5">
+            <div className="flex min-h-[84px] shrink-0 items-center gap-3 border-b border-[var(--border)] px-4 py-3 sm:min-h-[92px] sm:gap-4 sm:px-5">
               {normalizeImageUrl(activeConversation.itemImage || activeItem?.item_image) ? (
                 <img
                   src={normalizeImageUrl(activeConversation.itemImage || activeItem?.item_image)}
@@ -528,12 +528,12 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
                   className="h-14 w-14 shrink-0 rounded-md object-cover sm:h-16 sm:w-16"
                 />
               ) : (
-                <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-md bg-[#fff9e8] text-[#aaa] sm:h-16 sm:w-16">
+                <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-md bg-[var(--surface-strong)] text-[var(--text-soft)] sm:h-16 sm:w-16">
                   <Package className="h-5 w-5" />
                 </div>
               )}
               <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-bold text-[#2a2416]">
+                <p className="truncate text-sm font-bold text-[var(--text)]">
                   {activeConversation.itemTitle || activeItem?.item_title || '未关联商品'}
                 </p>
                 {activeItem?.item_price && (
@@ -542,16 +542,16 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
                     {String(activeItem.item_price).replace(/^[¥￥]\s*/, '')}
                   </p>
                 )}
-                <p className="mt-1 truncate text-xs text-[#999]">
+                <p className="mt-1 truncate text-xs text-[var(--text-soft)]">
                   {activeConversation.itemId ? `商品 ID ${activeConversation.itemId}` : '普通会话'}
                 </p>
               </div>
-              <span className="hidden rounded-md bg-[#ffe100] px-4 py-2 text-xs font-bold text-[#2a2416] sm:inline-flex">
+              <span className="hidden rounded-md bg-[var(--brand)] px-4 py-2 text-xs font-bold text-[var(--brand-ink)] sm:inline-flex">
                 {accountName(activeAccount)}
               </span>
             </div>
 
-            <div className="min-h-0 flex-1 overflow-y-auto bg-[#fffdf5] px-4 py-6 sm:px-8">
+            <div className="min-h-0 flex-1 overflow-y-auto bg-[var(--app-bg)] px-4 py-6 sm:px-8">
               {messagesLoading && messages.length === 0 ? (
                 <div className="flex h-full items-center justify-center">
                   <Loader2 className="h-6 w-6 animate-spin text-[#d6b600]" />
@@ -567,7 +567,7 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
                     return (
                       <div key={message.messageId || `${message.time}-${index}`}>
                         {showTime && (
-                          <p className="mb-3 text-center text-[11px] text-[#aaa]">
+                          <p className="mb-3 text-center text-[11px] text-[var(--text-soft)]">
                             {formatTimestamp(message.time)}
                           </p>
                         )}
@@ -578,7 +578,7 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
                             'h-9 w-9 shrink-0 rounded-full'
                           )}
                           <div className={`max-w-[76%] rounded-md px-3.5 py-2.5 text-sm leading-6 ${
-                            message.isSelf ? 'bg-[#ffe100] text-[#2a2416]' : 'bg-white text-[#333]'
+                            message.isSelf ? 'bg-[var(--brand)] text-[var(--brand-ink)]' : 'bg-[var(--surface-strong)] text-[var(--text)]'
                           }`}>
                             {message.images.map((url) => (
                               <img
@@ -602,19 +602,19 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
                     );
                   })}
                   {messages.length === 0 && !messagesLoading && (
-                    <p className="py-16 text-center text-sm text-[#999]">暂无聊天记录</p>
+                    <p className="py-16 text-center text-sm text-[var(--text-soft)]">暂无聊天记录</p>
                   )}
                   <div ref={messagesEndRef} />
                 </div>
               )}
             </div>
 
-            <footer className="shrink-0 border-t border-[#f0e6c8] bg-white px-4 py-3 sm:px-5">
-              <div className="mb-2 flex items-center gap-4 text-[#555]">
-                <button type="button" title="表情（暂未开放）" className="hover:text-[#111]">
+            <footer className="shrink-0 border-t border-[var(--border)] bg-[var(--surface)] px-4 py-3 sm:px-5">
+              <div className="mb-2 flex items-center gap-4 text-[var(--text-muted)]">
+                <button type="button" title="表情（暂未开放）" className="hover:text-[var(--text)]">
                   <Smile className="h-5 w-5" />
                 </button>
-                <button type="button" title="图片（暂未开放）" className="hover:text-[#111]">
+                <button type="button" title="图片（暂未开放）" className="hover:text-[var(--text)]">
                   <Image className="h-5 w-5" />
                 </button>
                 <div className="relative">
@@ -622,12 +622,12 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
                     type="button"
                     title="快捷短语"
                     onClick={() => setShowPhrases(value => !value)}
-                    className={`hover:text-[#111] ${showPhrases ? 'text-[#111]' : ''}`}
+                    className={`hover:text-[var(--text)] ${showPhrases ? 'text-[var(--text)]' : ''}`}
                   >
                     <Zap className="h-5 w-5" />
                   </button>
                   {showPhrases && (
-                    <div className="absolute bottom-8 left-0 z-20 max-h-72 w-80 overflow-y-auto rounded-lg border border-[#f0e6c8] bg-white p-2 shadow-lg">
+                    <div className="absolute bottom-8 left-0 z-20 max-h-72 w-80 overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--surface)] p-2 shadow-lg">
                       {quickPhrases.length === 0 ? (
                         <p className="px-2 py-3 text-xs text-gray-500">
                           还没有快捷短语，可在「设置」中添加。
@@ -638,9 +638,9 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
                             key={phrase.id}
                             type="button"
                             onClick={() => insertPhrase(phrase)}
-                            className="block w-full rounded-md px-2 py-2 text-left hover:bg-[#fffdf5]"
+                            className="block w-full rounded-md px-2 py-2 text-left hover:bg-[var(--surface-hover)]"
                           >
-                            <span className="block text-xs font-semibold text-[#2a2416]">
+                            <span className="block text-xs font-semibold text-[var(--text)]">
                               [{phrase.category}] {phrase.title}
                             </span>
                             <span className="mt-0.5 block truncate text-xs text-gray-500">
@@ -666,13 +666,13 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
                   rows={2}
                   placeholder={activeAccount?.connected ? '输入消息' : '账号离线，暂时无法发送'}
                   disabled={!activeAccount?.connected}
-                  className="min-h-[56px] min-w-0 flex-1 resize-none border-0 px-0 py-1 text-sm leading-6 outline-none placeholder:text-[#aaa] disabled:bg-white sm:min-h-[72px]"
+                  className="min-h-[56px] min-w-0 flex-1 resize-none border-0 bg-[var(--surface)] px-0 py-1 text-sm leading-6 text-[var(--text)] outline-none placeholder:text-[var(--text-soft)] disabled:bg-[var(--surface)] sm:min-h-[72px]"
                 />
                 <button
                   type="button"
                   onClick={() => void sendMessage()}
                   disabled={!draft.trim() || sending || !activeAccount?.connected}
-                  className="flex h-9 shrink-0 items-center gap-2 rounded-md bg-[#ffe100] px-4 text-sm font-bold text-[#2a2416] hover:bg-[#ffd700] disabled:cursor-not-allowed disabled:bg-[#fff9e8] disabled:text-[#aaa] sm:px-5"
+                  className="flex h-9 shrink-0 items-center gap-2 rounded-md bg-[var(--brand)] px-4 text-sm font-bold text-[var(--brand-ink)] hover:bg-[var(--brand-hover)] disabled:cursor-not-allowed disabled:bg-[var(--surface-strong)] disabled:text-[var(--text-soft)] sm:px-5"
                 >
                   {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
                   发送
@@ -682,9 +682,9 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
           </>
         ) : (
           <div className="flex flex-1 flex-col items-center justify-center px-6 text-center">
-            <Inbox className="h-12 w-12 text-[#d0d0d0]" />
-            <p className="mt-4 text-sm font-bold text-[#666]">选择一条会话查看消息</p>
-            <p className="mt-1 text-xs text-[#aaa]">会话和聊天记录直接来自当前闲鱼账号</p>
+            <Inbox className="h-12 w-12 text-[var(--text-soft)]" />
+            <p className="mt-4 text-sm font-bold text-[var(--text-muted)]">选择一条会话查看消息</p>
+            <p className="mt-1 text-xs text-[var(--text-soft)]">会话和聊天记录直接来自当前闲鱼账号</p>
           </div>
         )}
       </section>
@@ -692,7 +692,7 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
   );
 
   const renderFilters = () => (
-    <div className="h-full overflow-y-auto bg-[#fffdf5] p-4 sm:p-6 lg:p-8">
+    <div className="h-full overflow-y-auto bg-[var(--app-bg)] p-4 sm:p-6 lg:p-8">
       <div className="page-stack mx-auto max-w-[1320px]">
         <header className="page-header">
           <div>
@@ -807,7 +807,7 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
 
           <div className="divide-y divide-[#eeeeee] px-4">
             {filters.length > 0 && (
-              <label className="flex items-center gap-3 py-3 text-xs font-bold text-[#777]">
+              <label className="flex items-center gap-3 py-3 text-xs font-bold text-[var(--text-muted)]">
                 <input
                   type="checkbox"
                   checked={selectedAllFilters}
@@ -851,12 +851,12 @@ const MessageManagement: React.FC<MessageManagementProps> = ({ isActive = true }
                   }`} />
                 </button>
                 <div>
-                  <p className="break-all text-sm font-bold text-[#2a2416]">{filter.cookie_id}</p>
-                  <p className="mt-1 text-xs text-[#888]">{filterTypeLabel[filter.filter_type]}</p>
+                  <p className="break-all text-sm font-bold text-[var(--text)]">{filter.cookie_id}</p>
+                  <p className="mt-1 text-xs text-[var(--text-muted)]">{filterTypeLabel[filter.filter_type]}</p>
                 </div>
                 <div className="min-w-0">
-                  <p className="break-words text-sm font-medium text-[#333]">{filter.keyword}</p>
-                  <p className="mt-1 text-xs text-[#aaa]">
+                  <p className="break-words text-sm font-medium text-[var(--text)]">{filter.keyword}</p>
+                  <p className="mt-1 text-xs text-[var(--text-soft)]">
                     {formatDateTime(filter.updated_at || filter.created_at)}
                   </p>
                 </div>

--- a/frontend/components/OrderList.tsx
+++ b/frontend/components/OrderList.tsx
@@ -591,7 +591,7 @@ const OrderList: React.FC = () => {
                         {order.item_image ? (
                             <img src={order.item_image} alt="" className="w-full h-full object-cover" />
                         ) : (
-                            <div className="w-full h-full flex items-center justify-center text-gray-300"><PackageCheck /></div>
+                            <div className="w-full h-full flex items-center justify-center text-gray-400"><PackageCheck /></div>
                         )}
                       </div>
                       <div className="min-w-0">

--- a/frontend/components/ProductAutomation.tsx
+++ b/frontend/components/ProductAutomation.tsx
@@ -471,7 +471,7 @@ const ProductAutomation: React.FC = () => {
                                 className="h-full w-full object-cover"
                                 referrerPolicy="no-referrer"
                               />
-                            ) : <Archive className="m-3 h-6 w-6 text-gray-300" />}
+                            ) : <Archive className="m-3 h-6 w-6 text-gray-400" />}
                           </div>
                           <div className="min-w-0">
                             <div className="max-w-72 truncate font-bold text-gray-900">{material.title}</div>

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   X,
   Info,
 } from 'lucide-react';
+import ThemeToggle from './ThemeToggle';
 
 interface SidebarProps {
   activeTab: string;
@@ -77,7 +78,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab, onLogout, mo
         aria-label="关闭导航"
       />
     )}
-    <aside className={`fixed left-0 top-0 z-40 flex h-screen w-[248px] flex-col bg-white transition-transform lg:translate-x-0 ${
+    <aside className={`fixed left-0 top-0 z-40 flex h-screen w-[248px] flex-col bg-[var(--surface)] transition-transform lg:translate-x-0 ${
       mobileOpen ? 'translate-x-0' : '-translate-x-full'
     }`} style={{ borderRight: '1px solid var(--border)' }}>
       <div className="flex min-h-0 flex-1 flex-col">
@@ -93,10 +94,10 @@ const Sidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab, onLogout, mo
             <span className="text-lg font-black text-[#2a2416]">闲</span>
           </div>
           <div className="min-w-0 flex-1">
-            <p className="truncate text-base font-extrabold text-[#2a2416]">闲鱼超级管家</p>
-            <p className="mt-0.5 text-[11px] font-medium text-[#a89e83]">运营工作台</p>
+            <p className="truncate text-base font-extrabold text-[var(--text)]">闲鱼超级管家</p>
+            <p className="mt-0.5 text-[11px] font-medium text-[var(--text-soft)]">运营工作台</p>
           </div>
-          <button type="button" onClick={onMobileClose} className="rounded-full p-2 hover:bg-[#fff9e8] lg:hidden" aria-label="关闭导航">
+          <button type="button" onClick={onMobileClose} className="rounded-full p-2 hover:bg-[var(--surface-hover)] lg:hidden" aria-label="关闭导航">
             <X className="w-5 h-5" />
           </button>
         </div>
@@ -104,7 +105,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab, onLogout, mo
         <nav className="min-h-0 flex-1 overflow-y-auto px-3 pb-4">
           {menuGroups.map((group, groupIndex) => (
             <div key={group.label} className={groupIndex === 0 ? '' : 'mt-5'}>
-              <p className="mb-2 px-3 text-[11px] font-bold uppercase tracking-wide text-[#b8ac8e]">{group.label}</p>
+              <p className="mb-2 px-3 text-[11px] font-bold uppercase tracking-wide text-[var(--text-soft)]">{group.label}</p>
               <div className="space-y-1">
                 {group.items.map((item) => {
                   const Icon = item.icon;
@@ -117,14 +118,14 @@ const Sidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab, onLogout, mo
                       className={`group flex min-h-11 w-full items-center gap-3 rounded-xl px-3 text-left transition-all ${
                         isActive
                           ? 'font-bold text-[#2a2416]'
-                          : 'font-medium text-[#6e654f] hover:bg-[#fffdf0] hover:text-[#2a2416]'
+                          : 'font-medium text-[var(--text-muted)] hover:bg-[var(--surface-hover)] hover:text-[var(--text)]'
                       }`}
                       style={isActive ? {
                         background: 'linear-gradient(135deg, var(--brand-300), var(--brand))',
                         boxShadow: 'var(--shadow-brand)',
                       } : undefined}
                     >
-                      <Icon className={`h-[18px] w-[18px] shrink-0 ${isActive ? 'text-[#2a2416]' : 'text-[#a89e83] group-hover:text-[#6e654f]'}`} />
+                      <Icon className={`h-[18px] w-[18px] shrink-0 ${isActive ? 'text-[#2a2416]' : 'text-[var(--text-soft)] group-hover:text-[var(--text-muted)]'}`} />
                       <span className="truncate text-sm">{item.label}</span>
                     </button>
                   );
@@ -136,10 +137,11 @@ const Sidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab, onLogout, mo
       </div>
 
       <div className="shrink-0 p-3" style={{ borderTop: '1px solid var(--border)' }}>
+        <ThemeToggle className="mb-2" />
         <button
           type="button"
           onClick={onLogout}
-          className="flex min-h-11 w-full items-center gap-3 rounded-xl px-3 text-[#6e654f] transition-colors hover:bg-[#fff0f0] hover:text-[#e03131]"
+          className="flex min-h-11 w-full items-center gap-3 rounded-xl px-3 text-[var(--text-muted)] transition-colors hover:bg-[var(--danger-soft)] hover:text-[var(--danger)]"
         >
           <LogOut className="h-[18px] w-[18px]" />
           <span className="text-sm font-medium">退出登录</span>

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { ThemePreference, useTheme } from '../theme/ThemeProvider';
+
+interface ThemeToggleProps {
+  compact?: boolean;
+  className?: string;
+}
+
+const themeOptions: Array<{
+  value: ThemePreference;
+  label: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string }>;
+}> = [
+  { value: 'light', label: '浅色', description: '使用浅色主题', icon: Sun },
+  { value: 'dark', label: '深色', description: '使用深色主题', icon: Moon },
+  { value: 'system', label: '自动', description: '跟随系统外观', icon: Monitor },
+];
+
+const ThemeToggle: React.FC<ThemeToggleProps> = ({ compact = false, className = '' }) => {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex = index;
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      nextIndex = (index + 1) % themeOptions.length;
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      nextIndex = (index - 1 + themeOptions.length) % themeOptions.length;
+    } else if (event.key === 'Home') {
+      nextIndex = 0;
+    } else if (event.key === 'End') {
+      nextIndex = themeOptions.length - 1;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    const nextTheme = themeOptions[nextIndex].value;
+    setTheme(nextTheme);
+    event.currentTarget.parentElement
+      ?.querySelector<HTMLButtonElement>(`[data-theme-option="${nextTheme}"]`)
+      ?.focus();
+  };
+
+  return (
+    <div
+      className={`theme-picker ${compact ? 'theme-picker--compact' : ''} ${className}`.trim()}
+      data-resolved-theme={resolvedTheme}
+    >
+      {!compact && (
+        <div className="theme-picker__heading">
+          <span>显示主题</span>
+          <span className="theme-picker__status">
+            {theme === 'system' ? `自动 · ${resolvedTheme === 'dark' ? '深色' : '浅色'}` : theme === 'dark' ? '深色' : '浅色'}
+          </span>
+        </div>
+      )}
+      <div className="theme-switcher" role="radiogroup" aria-label="显示主题">
+        {themeOptions.map((option, index) => {
+          const Icon = option.icon;
+          const selected = theme === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-label={option.description}
+              title={option.description}
+              tabIndex={selected ? 0 : -1}
+              data-theme-option={option.value}
+              className={`theme-switcher__option ${selected ? 'theme-switcher__option--active' : ''}`}
+              onClick={() => setTheme(option.value)}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {!compact && <span>{option.label}</span>}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -8,7 +8,8 @@
   padding: 0;
 }
 
-:root {
+:root,
+:root[data-theme='light'] {
   color-scheme: light;
 
   /* 牛皮纸白：极低饱和的暖白，比纯白柔和但不发黄。
@@ -25,7 +26,19 @@
 
   --text: #23211e;
   --text-muted: #6b6862;
-  --text-soft: #9c9892;
+  --text-soft: #76716a;
+
+  /* Tailwind 灰阶改由主题变量驱动：背景色从浅到深，文字色亦保留原有层级。 */
+  --gray-50: 250 250 248;
+  --gray-100: 245 244 240;
+  --gray-200: 235 233 227;
+  --gray-300: 221 217 208;
+  --gray-400: 118 113 106;
+  --gray-500: 107 104 98;
+  --gray-600: 102 98 92;
+  --gray-700: 74 71 66;
+  --gray-800: 51 48 44;
+  --gray-900: 34 32 29;
 
   /* 品牌黄色阶：从浅到深，供背景、描边、悬停、按下各层使用 */
   --brand-50: #fffdf0;
@@ -37,14 +50,21 @@
   --brand-active: #f5c800;
   --brand-ink: #2a2416;        /* 黄底之上的文字色 */
   --brand-soft: #fff9c9;
+  --brand-text: #806d00;
+  --focus-ring: #806d00;
+  --unread-badge: #dc2626;
 
-  --danger: #e03131;
+  --danger: #b42318;
+  --danger-ink: #b42318;
   --danger-soft: #fff0f0;
-  --success: #0f9d58;
+  --success: #0f704b;
+  --success-ink: #0f704b;
   --success-soft: #eefaf3;
-  --warning: #d98600;
+  --warning: #945800;
+  --warning-ink: #945800;
   --warning-soft: #fff7e6;
-  --info: #2f7dd1;
+  --info: #2a5f92;
+  --info-ink: #2a5f92;
   --info-soft: #f0f7ff;
 
   /* 圆角成体系：控件 10、卡片 16、面板 20、胶囊 999 */
@@ -59,11 +79,81 @@
   --shadow-md: 0 6px 20px rgba(35, 33, 30, 0.08);
   --shadow-lg: 0 16px 40px rgba(35, 33, 30, 0.12);
   --shadow-brand: 0 6px 18px rgba(255, 214, 0, 0.35);
+  --chart-grid: #ebe9e3;
+  --chart-cursor: rgba(35, 33, 30, 0.06);
+  --scrollbar-thumb: #d6d3cc;
+  --scrollbar-thumb-hover: #b9b4aa;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+
+  /* 暖黑而非纯黑，延续闲鱼黄的品牌气质，同时拉开三个表面层级。 */
+  --app-bg: #11110f;
+  --surface: #191916;
+  --surface-subtle: #20201c;
+  --surface-strong: #292820;
+  --surface-hover: #302e27;
+
+  --border: #37362f;
+  --border-strong: #504c40;
+  --border-brand: #d9bd19;
+
+  --text: #f5f2e8;
+  --text-muted: #c2bcae;
+  --text-soft: #aaa59b;
+
+  /* 反转灰阶的语义亮度：bg-gray-50 变暗，text-gray-900 自动变亮。 */
+  --gray-50: 32 32 28;
+  --gray-100: 41 40 34;
+  --gray-200: 56 53 45;
+  --gray-300: 77 72 60;
+  --gray-400: 170 165 155;
+  --gray-500: 174 167 153;
+  --gray-600: 194 188 174;
+  --gray-700: 215 210 198;
+  --gray-800: 234 230 220;
+  --gray-900: 245 242 232;
+
+  /* 黄色仍保持醒目；浅黄底在暗色中改为低亮度金棕底。 */
+  --brand-50: #292617;
+  --brand-100: #373116;
+  --brand-200: #4b4015;
+  --brand-soft: #393216;
+  --brand-text: #f2d85c;
+  --focus-ring: #f2d85c;
+
+  --danger: #ff8c8c;
+  --danger-ink: #ffaaaa;
+  --danger-soft: #3a1e1e;
+  --success: #75d9a3;
+  --success-ink: #8fe0b5;
+  --success-soft: #173528;
+  --warning: #ffd170;
+  --warning-ink: #f3d77c;
+  --warning-soft: #3a2d16;
+  --info: #91c9ff;
+  --info-ink: #9dccff;
+  --info-soft: #182e45;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.28);
+  --shadow-md: 0 10px 28px rgba(0, 0, 0, 0.32);
+  --shadow-lg: 0 22px 60px rgba(0, 0, 0, 0.42);
+  --shadow-brand: 0 7px 22px rgba(221, 187, 0, 0.18);
+  --chart-grid: #403d36;
+  --chart-cursor: rgba(255, 255, 255, 0.06);
+  --scrollbar-thumb: #5b574e;
+  --scrollbar-thumb-hover: #d2bd38;
 }
 
 html, body, #root {
   height: 100%;
   width: 100%;
+}
+
+html {
+  background: var(--app-bg);
+  scrollbar-color: var(--scrollbar-thumb) transparent;
 }
 
 body {
@@ -87,8 +177,272 @@ input:focus-visible,
 select:focus-visible,
 textarea:focus-visible,
 a:focus-visible {
-  outline: 2px solid #bfaa00;
+  outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
+}
+
+input:disabled,
+select:disabled,
+textarea:disabled,
+input[readonly] {
+  color: var(--text-muted);
+}
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+textarea:-webkit-autofill,
+select:-webkit-autofill {
+  -webkit-text-fill-color: var(--text);
+  caret-color: var(--text);
+  box-shadow: 0 0 0 1000px var(--surface) inset;
+  transition: background-color 9999s ease-out 0s;
+}
+
+/* 三态主题选择器：选中态同时使用描边、底色和字重，不只依赖颜色。 */
+.theme-picker {
+  min-width: 0;
+  color: var(--text-muted);
+}
+
+.theme-picker__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 7px;
+  padding: 0 2px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.theme-picker__status {
+  color: var(--text-soft);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.theme-switcher {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 3px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-strong);
+  padding: 3px;
+}
+
+.theme-switcher__option {
+  display: inline-flex;
+  min-width: 0;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 650;
+  transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
+}
+
+.theme-switcher__option:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.theme-switcher__option--active,
+.theme-switcher__option--active:hover {
+  border-color: var(--border-brand);
+  background: var(--brand-soft);
+  color: var(--brand-text);
+  font-weight: 750;
+}
+
+.theme-picker--compact .theme-switcher {
+  grid-template-columns: repeat(3, 36px);
+  border-radius: 11px;
+}
+
+.theme-picker--compact .theme-switcher__option {
+  width: 36px;
+  min-height: 36px;
+}
+
+/* 二维码必须保留纯白扫描底，不参与深色反转。 */
+.media-light-surface {
+  color-scheme: light;
+  background: #ffffff !important;
+  color: #23211e !important;
+}
+
+:root[data-theme='dark'] .media-light-surface .bg-white,
+:root[data-theme='dark'] .media-light-surface [class~='bg-white/95'] {
+  background-color: rgba(255, 255, 255, 0.96) !important;
+}
+
+:root[data-theme='dark'] .media-light-surface .bg-gray-50,
+:root[data-theme='dark'] .media-light-surface .bg-green-50 {
+  background-color: #fafaf8 !important;
+}
+
+:root[data-theme='dark'] .media-light-surface .text-gray-500 { color: #6b6862 !important; }
+:root[data-theme='dark'] .media-light-surface .text-gray-800 { color: #33302c !important; }
+:root[data-theme='dark'] .media-light-surface .text-green-700 { color: #0f704b !important; }
+:root[data-theme='dark'] .media-light-surface .text-amber-800 { color: #7a5100 !important; }
+:root[data-theme='dark'] .media-light-surface .text-blue-600 { color: #245f9d !important; }
+:root[data-theme='dark'] .media-light-surface .text-red-600 { color: #c92a2a !important; }
+
+/* Tailwind 的纯白与少量历史硬编码暖白，统一落入暗色表面层。 */
+:root[data-theme='dark'] .bg-white {
+  background-color: var(--surface);
+}
+
+:root[data-theme='dark'] [class~='bg-white/95'] {
+  background-color: rgba(25, 25, 22, 0.96);
+}
+
+:root[data-theme='dark'] [class~='bg-white/90'],
+:root[data-theme='dark'] [class~='bg-white/80'] {
+  background-color: rgba(25, 25, 22, 0.9);
+}
+
+:root[data-theme='dark'] [class~='bg-[#fffdf5]'] { background-color: var(--app-bg); }
+:root[data-theme='dark'] [class~='bg-[#fff9e8]'],
+:root[data-theme='dark'] [class~='bg-[#fffdf0]'],
+:root[data-theme='dark'] [class~='bg-[#f5edd6]'] { background-color: var(--surface-strong); }
+:root[data-theme='dark'] [class~='hover:bg-[#fff9e8]']:hover,
+:root[data-theme='dark'] [class~='hover:bg-[#fffdf5]']:hover,
+:root[data-theme='dark'] [class~='hover:bg-[#fffdf0]']:hover { background-color: var(--surface-hover); }
+:root[data-theme='dark'] [class~='disabled:bg-white']:disabled { background-color: var(--surface); }
+
+:root[data-theme='dark'] [class~='border-[#f0e6c8]'],
+:root[data-theme='dark'] [class~='border-[#e6d69a]'] { border-color: var(--border); }
+
+:root[data-theme='dark'] [class~='text-[#111]'],
+:root[data-theme='dark'] [class~='text-[#333]'],
+:root[data-theme='dark'] [class~='text-[#555]'],
+:root[data-theme='dark'] [class~='text-[#666]'] { color: var(--text); }
+:root[data-theme='dark'] [class~='text-[#777]'],
+:root[data-theme='dark'] [class~='text-[#888]'] { color: var(--text-muted); }
+:root[data-theme='dark'] [class~='text-[#999]'],
+:root[data-theme='dark'] [class~='text-[#aaa]'],
+:root[data-theme='dark'] [class~='text-[#a89e83]'],
+:root[data-theme='dark'] [class~='text-[#b8ac8e]'],
+:root[data-theme='dark'] [class~='text-[#d0d0d0]'] { color: var(--text-soft); }
+:root[data-theme='dark'] [class~='text-[#8c7900]'],
+:root[data-theme='dark'] [class~='text-[#8a6300]'],
+:root[data-theme='dark'] [class~='text-[#6b5200]'],
+:root[data-theme='dark'] [class~='text-[#d6b600]'] { color: var(--brand-text); }
+:root[data-theme='dark'] [class~='hover:text-black']:hover,
+:root[data-theme='dark'] [class~='hover:text-[#111]']:hover { color: var(--text); }
+
+/* 开关圆点与二维码一样需要维持亮色，才能和关闭态轨道拉开边界。 */
+:root[data-theme='dark'] button .rounded-full.bg-white {
+  background-color: #f4f1e8;
+}
+
+/* 状态色成对调整，避免暗色页面上出现刺眼浅色块或暗字。 */
+:root[data-theme='dark'] .bg-red-50,
+:root[data-theme='dark'] .bg-red-100 { background-color: var(--danger-soft); }
+:root[data-theme='dark'] .border-red-200 { border-color: #744040; }
+:root[data-theme='dark'] .text-red-500,
+:root[data-theme='dark'] .text-red-600,
+:root[data-theme='dark'] .text-red-700,
+:root[data-theme='dark'] .text-red-800,
+:root[data-theme='dark'] .text-red-900 { color: #ffaaaa; }
+
+:root[data-theme='dark'] .bg-green-50,
+:root[data-theme='dark'] .bg-green-100,
+:root[data-theme='dark'] .bg-emerald-50 { background-color: var(--success-soft); }
+:root[data-theme='dark'] .border-green-200,
+:root[data-theme='dark'] .border-emerald-200 { border-color: #356b50; }
+:root[data-theme='dark'] .text-green-600,
+:root[data-theme='dark'] .text-green-700,
+:root[data-theme='dark'] .text-green-800,
+:root[data-theme='dark'] .text-emerald-600,
+:root[data-theme='dark'] .text-emerald-700,
+:root[data-theme='dark'] .text-emerald-800 { color: #8fe0b5; }
+
+:root[data-theme='dark'] .bg-blue-50,
+:root[data-theme='dark'] .bg-blue-100 { background-color: var(--info-soft); }
+:root[data-theme='dark'] .border-blue-200 { border-color: #3c638c; }
+:root[data-theme='dark'] .text-blue-500,
+:root[data-theme='dark'] .text-blue-600,
+:root[data-theme='dark'] .text-blue-700,
+:root[data-theme='dark'] .text-blue-800,
+:root[data-theme='dark'] .text-blue-900 { color: #9dccff; }
+
+:root[data-theme='dark'] .bg-yellow-50,
+:root[data-theme='dark'] .bg-yellow-100,
+:root[data-theme='dark'] .bg-amber-50,
+:root[data-theme='dark'] .bg-amber-100,
+:root[data-theme='dark'] .bg-amber-200 { background-color: var(--warning-soft); }
+:root[data-theme='dark'] .border-amber-200 { border-color: #755f2d; }
+:root[data-theme='dark'] .text-yellow-600,
+:root[data-theme='dark'] .text-yellow-700,
+:root[data-theme='dark'] .text-yellow-800,
+:root[data-theme='dark'] .text-amber-500,
+:root[data-theme='dark'] .text-amber-600,
+:root[data-theme='dark'] .text-amber-700,
+:root[data-theme='dark'] .text-amber-800,
+:root[data-theme='dark'] .text-amber-900 { color: #f3d77c; }
+
+:root[data-theme='dark'] [class~='bg-[#fff8d1]'] { background-color: #393216; }
+:root[data-theme='dark'] [class~='bg-[#eef4ff]'] { background-color: #1c2d45; }
+:root[data-theme='dark'] [class~='bg-[#f0f7f3]'] { background-color: #193126; }
+:root[data-theme='dark'] [class~='bg-[#f7f2fb]'] { background-color: #2c2438; }
+:root[data-theme='dark'] [class~='text-[#3f5f8f]'] { color: #aacbff; }
+:root[data-theme='dark'] [class~='text-[#3f7a5c]'] { color: #9bd9b5; }
+:root[data-theme='dark'] [class~='text-[#6b5a8a]'] { color: #d1baf2; }
+
+:root[data-theme='dark'] [class~='hover:bg-red-50']:hover,
+:root[data-theme='dark'] [class~='hover:bg-red-100']:hover { background-color: var(--danger-soft); }
+:root[data-theme='dark'] [class~='hover:bg-green-50']:hover,
+:root[data-theme='dark'] [class~='hover:bg-green-100']:hover,
+:root[data-theme='dark'] [class~='hover:bg-emerald-50']:hover { background-color: var(--success-soft); }
+:root[data-theme='dark'] [class~='hover:bg-blue-50']:hover,
+:root[data-theme='dark'] [class~='hover:bg-blue-100']:hover { background-color: var(--info-soft); }
+:root[data-theme='dark'] [class~='hover:bg-yellow-50']:hover,
+:root[data-theme='dark'] [class~='hover:bg-yellow-100']:hover,
+:root[data-theme='dark'] [class~='hover:bg-amber-50']:hover,
+:root[data-theme='dark'] [class~='hover:bg-amber-100']:hover { background-color: var(--warning-soft); }
+:root[data-theme='dark'] [class~='hover:bg-black/5']:hover { background-color: rgba(255, 255, 255, 0.08); }
+
+:root[data-theme='dark'] [class~='hover:text-red-600']:hover,
+:root[data-theme='dark'] [class~='hover:text-red-700']:hover { color: #ffaaaa; }
+:root[data-theme='dark'] [class~='hover:text-green-600']:hover,
+:root[data-theme='dark'] [class~='hover:text-green-700']:hover,
+:root[data-theme='dark'] [class~='hover:text-emerald-600']:hover { color: #8fe0b5; }
+:root[data-theme='dark'] [class~='hover:text-blue-600']:hover,
+:root[data-theme='dark'] [class~='hover:text-blue-700']:hover { color: #9dccff; }
+:root[data-theme='dark'] [class~='hover:text-amber-600']:hover,
+:root[data-theme='dark'] [class~='hover:text-amber-700']:hover { color: #f3d77c; }
+
+:root[data-theme='dark'] [class~='hover:bg-pink-50']:hover,
+:root[data-theme='dark'] [class~='hover:bg-pink-100']:hover { background-color: var(--danger-soft); }
+:root[data-theme='dark'] [class~='hover:text-pink-600']:hover,
+:root[data-theme='dark'] [class~='hover:text-pink-700']:hover,
+:root[data-theme='dark'] [class~='hover:text-yellow-600']:hover { color: var(--warning-ink); }
+:root[data-theme='dark'] [class~='hover:bg-amber-200']:hover { background-color: var(--warning-soft); }
+
+/* 登录页品牌面板永远是亮黄底，不能继承暗色表面的亮文字映射。 */
+:root[data-theme='dark'] .theme-brand-panel [class~='text-[#8a6300]'] { color: #8a6300; }
+:root[data-theme='dark'] .theme-brand-panel [class~='text-[#6b5200]'] { color: #6b5200; }
+
+:root[data-theme='dark'] .page-tab:not(.page-tab--active) .page-tab__count {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.recharts-pie-label-text,
+.recharts-text {
+  fill: var(--text-muted);
+}
+
+:root[data-theme='dark'] .modal-overlay,
+:root[data-theme='dark'] .modal-overlay-centered {
+  background-color: rgba(0, 0, 0, 0.68);
 }
 
 .page-stack {
@@ -306,27 +660,27 @@ a:focus-visible {
 }
 
 .notice-banner--success {
-  border-color: #b9e3d0;
+  border-color: color-mix(in srgb, var(--success) 38%, var(--border));
   background: var(--success-soft);
-  color: #0f704b;
+  color: var(--success-ink);
 }
 
 .notice-banner--error {
-  border-color: #f6c9c9;
+  border-color: color-mix(in srgb, var(--danger) 38%, var(--border));
   background: var(--danger-soft);
-  color: #b42318;
+  color: var(--danger-ink);
 }
 
 .notice-banner--warning {
   border-color: var(--border-strong);
   background: var(--warning-soft);
-  color: #945800;
+  color: var(--warning-ink);
 }
 
 .notice-banner--info {
-  border-color: #cbdff5;
+  border-color: color-mix(in srgb, var(--info) 38%, var(--border));
   background: var(--info-soft);
-  color: #2a5f92;
+  color: var(--info-ink);
 }
 
 .metric-grid {
@@ -502,14 +856,22 @@ a:focus-visible {
 
 .ios-input:focus {
   background: var(--surface);
-  border-color: var(--brand);
-  box-shadow: 0 0 0 4px rgba(255, 225, 0, 0.28);
+  border-color: var(--focus-ring);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--focus-ring) 28%, transparent);
   outline: none;
 }
 
 .ios-input::placeholder {
   color: var(--text-soft);
   font-weight: 400;
+}
+
+.ios-input:disabled,
+.ios-input[readonly] {
+  border-color: var(--border);
+  background: var(--surface-strong);
+  color: var(--text-muted);
+  cursor: not-allowed;
 }
 
 .ios-btn-primary {
@@ -569,14 +931,14 @@ a:focus-visible {
   background: var(--danger-soft);
   color: var(--danger);
   font-weight: 600;
-  border: 1px solid #f6c9c9;
+  border: 1px solid color-mix(in srgb, var(--danger) 38%, var(--border));
   transition: background-color 0.15s ease, border-color 0.15s ease;
   cursor: pointer;
 }
 
 .ios-btn-danger:hover:not(:disabled) {
-  background: #ffe3e3;
-  border-color: #f19a9a;
+  background: color-mix(in srgb, var(--danger-soft) 82%, var(--danger));
+  border-color: color-mix(in srgb, var(--danger) 62%, var(--border));
 }
 
 .data-table {
@@ -601,7 +963,7 @@ a:focus-visible {
 
 .data-table td {
   padding: 13px 16px;
-  border-bottom: 1px solid #eef0f2;
+  border-bottom: 1px solid var(--border);
   vertical-align: middle;
 }
 
@@ -623,12 +985,12 @@ a:focus-visible {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--border-strong);
+  background: var(--scrollbar-thumb);
   border-radius: var(--radius-pill);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--brand-active);
+  background: var(--scrollbar-thumb-hover);
 }
 
 /* 侧边栏导航：滚动条按需出现，常驻的黄色轨道会在品牌区旁边多出一条竖线 */
@@ -698,17 +1060,17 @@ aside nav:hover::-webkit-scrollbar-thumb {
 
 .status-badge-success {
   background-color: var(--success-soft);
-  color: #0b7a45;
+  color: var(--success-ink);
 }
 
 .status-badge-warning {
   background-color: var(--brand-100);
-  color: #8a6300;
+  color: var(--warning-ink);
 }
 
 .status-badge-error {
   background-color: var(--danger-soft);
-  color: #b42318;
+  color: var(--danger-ink);
 }
 
 /* info 徽标多用于"N 件商品/N 个账号"这类计数，走品牌黄比蓝色更贴主题；
@@ -738,7 +1100,8 @@ aside nav:hover::-webkit-scrollbar-thumb {
   margin: auto;
   display: flex;
   flex-direction: column;
-  background-color: white;
+  background-color: var(--surface);
+  color: var(--text);
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-lg);
@@ -758,6 +1121,7 @@ aside nav:hover::-webkit-scrollbar-thumb {
   overflow-y: auto;
   overflow-x: hidden;
   padding: 22px;
+  color: var(--text);
 }
 
 .modal-footer {
@@ -881,7 +1245,8 @@ aside nav:hover::-webkit-scrollbar-thumb {
   margin: auto 0;
   display: flex;
   flex-direction: column;
-  background-color: white;
+  background-color: var(--surface);
+  color: var(--text);
   border-radius: var(--radius);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-md);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>闲鱼超级管家 - 自动发货与运营工作台</title>
     <meta name="description" content="闲鱼自动回复、自动发货、订单管理、AI智能议价一体化解决方案" />
+    <script>
+      (() => {
+        try {
+          const stored = localStorage.getItem('xianyu-theme-preference');
+          const preference = ['light', 'dark', 'system'].includes(stored) ? stored : 'system';
+          const resolved = preference === 'system'
+            ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+            : preference;
+          document.documentElement.dataset.theme = resolved;
+          document.documentElement.dataset.themePreference = preference;
+          document.documentElement.classList.toggle('dark', resolved === 'dark');
+          document.documentElement.style.colorScheme = resolved;
+        } catch {
+          document.documentElement.dataset.theme = 'light';
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import { ThemeProvider } from './theme/ThemeProvider';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -11,6 +12,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,6 +4,7 @@
 // 全站有 395 处 rounded-md、130+ 处 bg-gray-*，逐处替换既容易漏又难回退。
 // 把 md 圆角调大、把 gray 色阶换成暖调，所有组件一次到位。
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./*.{js,ts,jsx,tsx}",
@@ -29,16 +30,16 @@ export default {
         // 中性色阶：只带极轻微的暖调，避免和黄色强调元素冲突。
         // 不做成黄色系 —— 全站 130+ 处 bg-gray-* 一旦变黄会让整页发闷。
         gray: {
-          50: '#FAFAF8',
-          100: '#F5F4F0',
-          200: '#EBE9E3',
-          300: '#DDD9D0',
-          400: '#B0AAA0',
-          500: '#85807A',
-          600: '#66625C',
-          700: '#4A4742',
-          800: '#33302C',
-          900: '#22201D',
+          50: 'rgb(var(--gray-50) / <alpha-value>)',
+          100: 'rgb(var(--gray-100) / <alpha-value>)',
+          200: 'rgb(var(--gray-200) / <alpha-value>)',
+          300: 'rgb(var(--gray-300) / <alpha-value>)',
+          400: 'rgb(var(--gray-400) / <alpha-value>)',
+          500: 'rgb(var(--gray-500) / <alpha-value>)',
+          600: 'rgb(var(--gray-600) / <alpha-value>)',
+          700: 'rgb(var(--gray-700) / <alpha-value>)',
+          800: 'rgb(var(--gray-800) / <alpha-value>)',
+          900: 'rgb(var(--gray-900) / <alpha-value>)',
         },
       },
       borderRadius: {

--- a/frontend/theme/ThemeProvider.tsx
+++ b/frontend/theme/ThemeProvider.tsx
@@ -1,0 +1,105 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+const THEME_STORAGE_KEY = 'xianyu-theme-preference';
+const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+interface ThemeContextValue {
+  theme: ThemePreference;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: ThemePreference) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const normalizeTheme = (value: string | null): ThemePreference => (
+  value === 'light' || value === 'dark' || value === 'system' ? value : 'system'
+);
+
+const readStoredTheme = (): ThemePreference => {
+  if (typeof window === 'undefined') return 'system';
+  try {
+    return normalizeTheme(window.localStorage.getItem(THEME_STORAGE_KEY));
+  } catch {
+    return 'system';
+  }
+};
+
+const readSystemTheme = (): ResolvedTheme => {
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia(DARK_MEDIA_QUERY).matches ? 'dark' : 'light';
+};
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setThemeState] = useState<ThemePreference>(readStoredTheme);
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(readSystemTheme);
+
+  useEffect(() => {
+    const media = window.matchMedia(DARK_MEDIA_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? 'dark' : 'light');
+    };
+
+    setSystemTheme(media.matches ? 'dark' : 'light');
+    media.addEventListener('change', handleChange);
+    return () => media.removeEventListener('change', handleChange);
+  }, []);
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === THEME_STORAGE_KEY) {
+        setThemeState(normalizeTheme(event.newValue));
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  const resolvedTheme = theme === 'system' ? systemTheme : theme;
+
+  useLayoutEffect(() => {
+    const root = document.documentElement;
+    root.dataset.theme = resolvedTheme;
+    root.dataset.themePreference = theme;
+    root.classList.toggle('dark', resolvedTheme === 'dark');
+    root.style.colorScheme = resolvedTheme;
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // 存储被浏览器禁用时，主题仍在当前页面内正常生效。
+    }
+  }, [resolvedTheme, theme]);
+
+  const setTheme = useCallback((nextTheme: ThemePreference) => {
+    setThemeState(nextTheme);
+  }, []);
+
+  const value = useMemo(
+    () => ({ theme, resolvedTheme, setTheme }),
+    [resolvedTheme, setTheme, theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = (): ThemeContextValue => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used inside ThemeProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## 功能说明

- 新增浅色、深色、跟随系统三档主题，支持登录页、桌面侧边栏和移动端入口
- 使用 localStorage 持久化主题偏好，并监听系统主题变化与跨标签页同步
- 在首屏渲染前初始化主题，避免深色模式刷新时出现白闪
- 完善键盘方向键切换和 ARIA 单选组语义
- 建立暗色语义色、状态色、焦点色及 Tailwind 灰阶映射
- 适配消息中心、仪表盘图表、弹窗、表格、滚动条、二维码和浏览器自动填充
- 修复浅色/深色下多处文字、状态徽标及交互控件的对比度问题

## 验证

- 	sc --noEmit
- 
pm run build
- git diff --check origin/main...HEAD
- 浏览器验证浅色、深色、跟随系统、刷新持久化和跨标签页同步
- 登录页自动对比度扫描：普通文字无低于 4.5:1 的结果