### PR TITLE
feat(ai): 支持 User-Agent 自定义以兼容 UA 白名单网关

### DIFF
--- a/app/ai_reply_engine.py
+++ b/app/ai_reply_engine.py
@@ -82,6 +82,7 @@ class AIReplyEngine:
                 api_key=settings['api_key'],
                 base_url=settings['base_url'],
                 timeout=30.0,
+                default_headers={"User-Agent": settings.get('user_agent') or 'codex_cli_rs/0.0.0 (Hermes Agent)'},
             )
             logger.info(f"为账号 {cookie_id} 创建OpenAI客户端成功，实际base_url: {client.base_url}")
             return client

--- a/app/db_manager.py
+++ b/app/db_manager.py
@@ -166,6 +166,7 @@ class DBManager:
                 model_name TEXT DEFAULT 'qwen-plus',
                 api_key TEXT,
                 base_url TEXT DEFAULT 'https://ai.corleom.com/v1',
+                user_agent TEXT,
                 max_discount_percent INTEGER DEFAULT 10,
                 max_discount_amount INTEGER DEFAULT 100,
                 max_bargain_rounds INTEGER DEFAULT 3,
@@ -804,6 +805,10 @@ class DBManager:
                         f"ALTER TABLE ai_reply_settings ADD COLUMN {column_name} {column_type}"
                     )
                     logger.info(f"数据库迁移完成：添加AI设置列 {column_name}")
+
+            if 'user_agent' not in ai_setting_columns:
+                cursor.execute("ALTER TABLE ai_reply_settings ADD COLUMN user_agent TEXT")
+                logger.info("数据库迁移完成：添加AI设置列 user_agent")
 
             # 确保商品同步配置存在
             cursor.execute("SELECT key FROM system_settings WHERE key IN ('item_sync_enabled', 'item_sync_interval', 'item_sync_max_pages')")
@@ -2440,17 +2445,18 @@ class DBManager:
                 cursor = self.conn.cursor()
                 cursor.execute('''
                 INSERT OR REPLACE INTO ai_reply_settings
-                (cookie_id, ai_enabled, model_name, api_key, base_url,
+                (cookie_id, ai_enabled, model_name, api_key, base_url, user_agent,
                  max_discount_percent, max_discount_amount, max_bargain_rounds,
                  context_enabled, context_message_limit, context_expire_minutes,
                  custom_prompts, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
                 ''', (
                     cookie_id,
                     settings.get('ai_enabled', False),
                     settings.get('model_name', 'qwen-plus'),
                     settings.get('api_key', ''),
                     settings.get('base_url', 'https://ai.corleom.com/v1'),
+                    settings.get('user_agent', ''),
                     settings.get('max_discount_percent', 10),
                     settings.get('max_discount_amount', 100),
                     settings.get('max_bargain_rounds', 3),
@@ -2481,7 +2487,7 @@ class DBManager:
             try:
                 cursor = self.conn.cursor()
                 cursor.execute('''
-                SELECT ai_enabled, model_name, api_key, base_url,
+                SELECT ai_enabled, model_name, api_key, base_url, user_agent,
                        max_discount_percent, max_discount_amount, max_bargain_rounds,
                        context_enabled, context_message_limit, context_expire_minutes,
                        custom_prompts
@@ -2511,13 +2517,14 @@ class DBManager:
                         'model_name': use_model,
                         'api_key': use_api_key,
                         'base_url': use_base_url,
-                        'max_discount_percent': result[4],
-                        'max_discount_amount': result[5],
-                        'max_bargain_rounds': result[6],
-                        'context_enabled': bool(result[7]),
-                        'context_message_limit': result[8] or 12,
-                        'context_expire_minutes': result[9] or 120,
-                        'custom_prompts': result[10]
+                        'user_agent': result[4] or '',
+                        'max_discount_percent': result[5],
+                        'max_discount_amount': result[6],
+                        'max_bargain_rounds': result[7],
+                        'context_enabled': bool(result[8]),
+                        'context_message_limit': result[9] or 12,
+                        'context_expire_minutes': result[10] or 120,
+                        'custom_prompts': result[11]
                     }
                 else:
                     # 账号没有设置，使用系统设置作为默认值
@@ -2526,6 +2533,7 @@ class DBManager:
                         'model_name': system_model,
                         'api_key': system_api_key,
                         'base_url': system_base_url,
+                        'user_agent': '',
                         'max_discount_percent': 10,
                         'max_discount_amount': 100,
                         'max_bargain_rounds': 3,
@@ -2541,6 +2549,7 @@ class DBManager:
                     'model_name': 'qwen-plus',
                     'api_key': '',
                     'base_url': 'https://ai.corleom.com/v1',
+                    'user_agent': '',
                     'max_discount_percent': 10,
                     'max_discount_amount': 100,
                     'max_bargain_rounds': 3,
@@ -2571,7 +2580,7 @@ class DBManager:
             try:
                 cursor = self.conn.cursor()
                 cursor.execute('''
-                SELECT cookie_id, ai_enabled, model_name, api_key, base_url,
+                SELECT cookie_id, ai_enabled, model_name, api_key, base_url, user_agent,
                        max_discount_percent, max_discount_amount, max_bargain_rounds,
                        context_enabled, context_message_limit, context_expire_minutes,
                        custom_prompts
@@ -2586,13 +2595,14 @@ class DBManager:
                         'model_name': row[2],
                         'api_key': row[3],
                         'base_url': row[4],
-                        'max_discount_percent': row[5],
-                        'max_discount_amount': row[6],
-                        'max_bargain_rounds': row[7],
-                        'context_enabled': bool(row[8]),
-                        'context_message_limit': row[9] or 12,
-                        'context_expire_minutes': row[10] or 120,
-                        'custom_prompts': row[11]
+                        'user_agent': row[5] or '',
+                        'max_discount_percent': row[6],
+                        'max_discount_amount': row[7],
+                        'max_bargain_rounds': row[8],
+                        'context_enabled': bool(row[9]),
+                        'context_message_limit': row[10] or 12,
+                        'context_expire_minutes': row[11] or 120,
+                        'custom_prompts': row[12]
                     }
 
                 return result

--- a/app/reply_server.py
+++ b/app/reply_server.py
@@ -5885,6 +5885,7 @@ class AIReplySettings(BaseModel):
     model_name: str = "qwen-plus"
     api_key: str = ""
     base_url: str = "https://ai.corleom.com/v1"
+    user_agent: str = ""
     max_discount_percent: int = 10
     max_discount_amount: int = 100
     max_bargain_rounds: int = 3

--- a/frontend/components/AIReply.tsx
+++ b/frontend/components/AIReply.tsx
@@ -31,6 +31,7 @@ const defaultSettings: AIReplySettings = {
   api_key: '',
   api_key_configured: false,
   base_url: FREE_TOKEN_BASE_URL,
+  user_agent: 'codex_cli_rs/0.0.0 (Hermes Agent)',
   max_discount_percent: 10,
   max_discount_amount: 100,
   max_bargain_rounds: 3,
@@ -273,6 +274,16 @@ const AIReply: React.FC = () => {
                         {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                       </button>
                     </div>
+                  </label>
+                  <label className="md:col-span-2">
+                    <span className="mb-1.5 block text-sm font-semibold text-gray-700">User-Agent</span>
+                    <input
+                      value={settings.user_agent ?? ''}
+                      onChange={event => updateSetting('user_agent', event.target.value)}
+                      className="ios-input w-full rounded-md px-3 py-2.5 text-sm"
+                      placeholder="codex_cli_rs/0.0.0 (Hermes Agent)"
+                    />
+                    <span className="mt-1 block text-xs text-gray-500">部分 API 中转站（如 AgentRouter）通过 User-Agent 白名单检测客户端，留空使用默认值。</span>
                   </label>
                 </div>
               </section>

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -537,6 +537,7 @@ export interface AIReplySettings {
   api_key: string;
   api_key_configured?: boolean;
   base_url: string;
+  user_agent?: string;
   max_discount_percent: number;
   max_discount_amount?: number;
   max_bargain_rounds: number;


### PR DESCRIPTION
部分 API 中转站（如 AgentRouter）通过 User-Agent 白名单检测客户端，
OpenAI SDK 默认 UA 不在白名单会被 401 拦截。新增 user_agent 配置字段， 允许用户在 AI 回复设置中自定义 User-Agent，留空时回退到默认值
codex_cli_rs/0.0.0 (Hermes Agent)。

改动覆盖完整链路（6 个文件）：
- db_manager.py: 建表加列 + 迁移 + save/get/get_all 存取
- ai_reply_engine.py: OpenAI() 构造注入 default_headers
- reply_server.py: Pydantic 模型加 user_agent 字段
- types.ts: AIReplySettings 接口加字段
- AIReply.tsx: 默认值 + UI 输入框