### PR TITLE
fix: 修复#53 docker环境缺少nodejs依赖

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ RUN apt-get update && \
         libgl1 \
         libglib2.0-0 \
         xvfb \
-        x11-utils && \
+        x11-utils \
+        nodejs \
+        npm && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/venv /opt/venv

--- a/Dockerfile-cn
+++ b/Dockerfile-cn
@@ -68,7 +68,9 @@ RUN apt-get update && \
         libgl1 \
         libglib2.0-0 \
         xvfb \
-        x11-utils && \
+        x11-utils \
+        nodejs \
+        npm && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/venv /opt/venv


### PR DESCRIPTION
修复#53 docker环境缺少nodejs依赖
关联 #53 
```bash
2026-09-02 19:05:09.349 | INFO     | utils.xianyu_utils:<module>:25 - 可用的JavaScript运行时: <module 'execjs.runtime_names' from '/opt/venv/lib/python3.11/site-packages/execjs/runtime_names.py'>
2026-09-02 19:05:09.349 | ERROR    | utils.xianyu_utils:<module>:35 - JavaScript运行时错误: Could not find an available JavaScript runtime.
2026-09-02 19:05:09.349 | ERROR    | utils.xianyu_utils:<module>:38 - 解决方案:
2026-09-02 19:05:09.350 | ERROR    | utils.xianyu_utils:<module>:39 - 1. 确保已安装Node.js: apt-get install nodejs
2026-09-02 19:05:09.350 | ERROR    | utils.xianyu_utils:<module>:40 - 2. 或安装其他JS运行时: apt-get install nodejs npm
2026-09-02 19:05:09.350 | ERROR    | utils.xianyu_utils:<module>:41 - 3. 检查PATH环境变量是否包含Node.js路径
2026-09-02 19:05:09.351 | ERROR    | utils.xianyu_utils:<module>:52 - 未找到Node.js可执行文件
2026-09-02 19:05:09.352 | ERROR    | __main__:_start_api_server:724 - uvicorn服务器启动失败: 无法加载JavaScript文件: Could not find an available JavaScript runtime.
```